### PR TITLE
Update to OpenJPEG 2.5.0

### DIFF
--- a/build_tools/cmake/CMakeLists.txt
+++ b/build_tools/cmake/CMakeLists.txt
@@ -15,7 +15,7 @@ endif()
 #string(TOLOWER ${OPENJPEG_NAMESPACE} OPENJPEG_LIBRARY_NAME)
 set(OPENJPEG_LIBRARY_NAME openjp2)
 
-project(${OPENJPEG_NAMESPACE})
+project(${OPENJPEG_NAMESPACE} C)
 
 # Do full dependency headers.
 include_regular_expression("^.*$")
@@ -23,8 +23,8 @@ include_regular_expression("^.*$")
 #-----------------------------------------------------------------------------
 # OPENJPEG version number, useful for packaging and doxygen doc:
 set(OPENJPEG_VERSION_MAJOR 2)
-set(OPENJPEG_VERSION_MINOR 3)
-set(OPENJPEG_VERSION_BUILD 1)
+set(OPENJPEG_VERSION_MINOR 5)
+set(OPENJPEG_VERSION_BUILD 0)
 set(OPENJPEG_VERSION
   "${OPENJPEG_VERSION_MAJOR}.${OPENJPEG_VERSION_MINOR}.${OPENJPEG_VERSION_BUILD}")
 set(PACKAGE_VERSION
@@ -36,7 +36,40 @@ endif(NOT OPENJPEG_SOVERSION)
 set(OPENJPEG_LIBRARY_PROPERTIES
   VERSION   "${OPENJPEG_VERSION_MAJOR}.${OPENJPEG_VERSION_MINOR}.${OPENJPEG_VERSION_BUILD}"
   SOVERSION "${OPENJPEG_SOVERSION}"
- )
+)
+
+# --------------------------------------------------------------------------
+# Path to additional CMake modules
+set(CMAKE_MODULE_PATH
+    ${${OPENJPEG_NAMESPACE}_SOURCE_DIR}/cmake
+    ${CMAKE_MODULE_PATH})
+
+# --------------------------------------------------------------------------
+# On Visual Studio 8 MS deprecated C. This removes all 1.276E1265 security
+# warnings
+if(WIN32)
+  if(NOT BORLAND)
+    if(NOT CYGWIN)
+      if(NOT MINGW)
+        if(NOT ITK_ENABLE_VISUAL_STUDIO_DEPRECATED_C_WARNINGS)
+          add_definitions(
+            -D_CRT_FAR_MAPPINGS_NO_DEPRECATE
+            -D_CRT_IS_WCTYPE_NO_DEPRECATE
+            -D_CRT_MANAGED_FP_NO_DEPRECATE
+            -D_CRT_NONSTDC_NO_DEPRECATE
+            -D_CRT_SECURE_NO_DEPRECATE
+            -D_CRT_SECURE_NO_DEPRECATE_GLOBALS
+            -D_CRT_SETERRORMODE_BEEP_SLEEP_NO_DEPRECATE
+            -D_CRT_TIME_FUNCTIONS_NO_DEPRECATE
+            -D_CRT_VCCLRIT_NO_DEPRECATE
+            -D_SCL_SECURE_NO_DEPRECATE
+            )
+        endif()
+      endif()
+    endif()
+  endif()
+endif()
+
 
 # --------------------------------------------------------------------------
 # Install directories
@@ -46,22 +79,21 @@ endif()
 
 set(OPENJPEG_INSTALL_PACKAGE_DIR "../interface")
 
-# --------------------------------------------------------------------------
-# Path to additional CMake modules
-set(CMAKE_MODULE_PATH
-    ${${OPENJPEG_NAMESPACE}_SOURCE_DIR}/cmake
-    ${CMAKE_MODULE_PATH})
-
 set(OPENJPEG_INSTALL_INCLUDE_DIR
     "../interface"
 )
 
-option(BUILD_JPIP "Build the JPIP library and executables." OFF)
+option(BUILD_JPWL off)
+option(BUILD_MJ2 off)
+option(BUILD_JPIP off)
+option(BUILD_JP3D off)
 
 #-----------------------------------------------------------------------------
 # Big endian test:
+if (NOT EMSCRIPTEN)
 include (${CMAKE_ROOT}/Modules/TestBigEndian.cmake)
 TEST_BIG_ENDIAN(OPJ_BIG_ENDIAN)
+endif()
 
 
 #-----------------------------------------------------------------------------

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ def setup_oj():
 setup_oj()
 
 # Compiler and linker arguments
-extra_compile_args = []
+extra_compile_args = ["-DOPJ_STATIC"]
 extra_link_args = []
 
 # Maybe use cythonize instead


### PR DESCRIPTION
This PR is similar to #54 but also includes updates to the CMAKE file which changed upstream and fixes the windows builds by enforcing static linking with `-DOPJ_STATIC` (https://github.com/jmsmkn/pylibjpeg-openjpeg/pull/4).

cc @mrbean-bremen - wasn't sure whether to target your branch or main, please feel free to change the target.

Closes #53 