### PR TITLE
Update cibuildwheel for Python 3.11 support

### DIFF
--- a/.github/workflows/release-wheels.yml
+++ b/.github/workflows/release-wheels.yml
@@ -174,7 +174,7 @@ jobs:
     - name: Install cibuildwheel
       run: |
         python -m pip install -U pip
-        python -m pip install cibuildwheel==2.3.1
+        python -m pip install cibuildwheel==2.12.0
 
     - name: Build wheels
       env:


### PR DESCRIPTION
This PR fixes the release build failures seen after #58, support for Python 3.11 was not added to cibuildwheel until [v2.11.2](https://github.com/pypa/cibuildwheel/releases?page=1). Apologies for the oversight in the previous PR.

CI release build for this PR can be found [here](https://github.com/jmsmkn/pylibjpeg-openjpeg/actions/runs/4218146139).