### PR TITLE
Add test for missing lines, make magic numbers customisable

### DIFF
--- a/openjpeg/__init__.py
+++ b/openjpeg/__init__.py
@@ -1,4 +1,4 @@
 """Set package shortcuts."""
 
-from ._version import __version__
-from .utils import decode, decode_pixel_data, get_parameters
+from ._version import __version__  # noqa: F401
+from .utils import decode, decode_pixel_data, get_parameters  # noqa: F401

--- a/openjpeg/_openjpeg.c
+++ b/openjpeg/_openjpeg.c
@@ -4,16 +4,16 @@
 {
     "distutils": {
         "depends": [
-            "/tmp/pip-build-env-x4mieqja/overlay/lib/python3.12/site-packages/numpy/core/include/numpy/arrayobject.h",
-            "/tmp/pip-build-env-x4mieqja/overlay/lib/python3.12/site-packages/numpy/core/include/numpy/arrayscalars.h",
-            "/tmp/pip-build-env-x4mieqja/overlay/lib/python3.12/site-packages/numpy/core/include/numpy/ndarrayobject.h",
-            "/tmp/pip-build-env-x4mieqja/overlay/lib/python3.12/site-packages/numpy/core/include/numpy/ndarraytypes.h",
-            "/tmp/pip-build-env-x4mieqja/overlay/lib/python3.12/site-packages/numpy/core/include/numpy/ufuncobject.h"
+            "/tmp/pip-build-env-1f1oalyc/overlay/lib/python3.8/site-packages/numpy/core/include/numpy/arrayobject.h",
+            "/tmp/pip-build-env-1f1oalyc/overlay/lib/python3.8/site-packages/numpy/core/include/numpy/arrayscalars.h",
+            "/tmp/pip-build-env-1f1oalyc/overlay/lib/python3.8/site-packages/numpy/core/include/numpy/ndarrayobject.h",
+            "/tmp/pip-build-env-1f1oalyc/overlay/lib/python3.8/site-packages/numpy/core/include/numpy/ndarraytypes.h",
+            "/tmp/pip-build-env-1f1oalyc/overlay/lib/python3.8/site-packages/numpy/core/include/numpy/ufuncobject.h"
         ],
         "include_dirs": [
             "/home/dean/Coding/src/pylibjpeg-openjpeg/lib/openjpeg/src/lib/openjp2",
             "/home/dean/Coding/src/pylibjpeg-openjpeg/lib/interface",
-            "/tmp/pip-build-env-x4mieqja/overlay/lib/python3.12/site-packages/numpy/core/include"
+            "/tmp/pip-build-env-1f1oalyc/overlay/lib/python3.8/site-packages/numpy/core/include"
         ],
         "language": "c",
         "name": "_openjpeg",
@@ -1550,7 +1550,7 @@ static const char *__pyx_f[] = {
 
 /* #### Code section: numeric_typedefs ### */
 
-/* "../../../../../tmp/pip-build-env-x4mieqja/overlay/lib/python3.12/site-packages/numpy/__init__.cython-30.pxd":730
+/* "../../../../../tmp/pip-build-env-1f1oalyc/overlay/lib/python3.8/site-packages/numpy/__init__.cython-30.pxd":731
  * # in Cython to enable them only on the right systems.
  * 
  * ctypedef npy_int8       int8_t             # <<<<<<<<<<<<<<
@@ -1559,7 +1559,7 @@ static const char *__pyx_f[] = {
  */
 typedef npy_int8 __pyx_t_5numpy_int8_t;
 
-/* "../../../../../tmp/pip-build-env-x4mieqja/overlay/lib/python3.12/site-packages/numpy/__init__.cython-30.pxd":731
+/* "../../../../../tmp/pip-build-env-1f1oalyc/overlay/lib/python3.8/site-packages/numpy/__init__.cython-30.pxd":732
  * 
  * ctypedef npy_int8       int8_t
  * ctypedef npy_int16      int16_t             # <<<<<<<<<<<<<<
@@ -1568,7 +1568,7 @@ typedef npy_int8 __pyx_t_5numpy_int8_t;
  */
 typedef npy_int16 __pyx_t_5numpy_int16_t;
 
-/* "../../../../../tmp/pip-build-env-x4mieqja/overlay/lib/python3.12/site-packages/numpy/__init__.cython-30.pxd":732
+/* "../../../../../tmp/pip-build-env-1f1oalyc/overlay/lib/python3.8/site-packages/numpy/__init__.cython-30.pxd":733
  * ctypedef npy_int8       int8_t
  * ctypedef npy_int16      int16_t
  * ctypedef npy_int32      int32_t             # <<<<<<<<<<<<<<
@@ -1577,7 +1577,7 @@ typedef npy_int16 __pyx_t_5numpy_int16_t;
  */
 typedef npy_int32 __pyx_t_5numpy_int32_t;
 
-/* "../../../../../tmp/pip-build-env-x4mieqja/overlay/lib/python3.12/site-packages/numpy/__init__.cython-30.pxd":733
+/* "../../../../../tmp/pip-build-env-1f1oalyc/overlay/lib/python3.8/site-packages/numpy/__init__.cython-30.pxd":734
  * ctypedef npy_int16      int16_t
  * ctypedef npy_int32      int32_t
  * ctypedef npy_int64      int64_t             # <<<<<<<<<<<<<<
@@ -1586,7 +1586,7 @@ typedef npy_int32 __pyx_t_5numpy_int32_t;
  */
 typedef npy_int64 __pyx_t_5numpy_int64_t;
 
-/* "../../../../../tmp/pip-build-env-x4mieqja/overlay/lib/python3.12/site-packages/numpy/__init__.cython-30.pxd":737
+/* "../../../../../tmp/pip-build-env-1f1oalyc/overlay/lib/python3.8/site-packages/numpy/__init__.cython-30.pxd":738
  * #ctypedef npy_int128     int128_t
  * 
  * ctypedef npy_uint8      uint8_t             # <<<<<<<<<<<<<<
@@ -1595,7 +1595,7 @@ typedef npy_int64 __pyx_t_5numpy_int64_t;
  */
 typedef npy_uint8 __pyx_t_5numpy_uint8_t;
 
-/* "../../../../../tmp/pip-build-env-x4mieqja/overlay/lib/python3.12/site-packages/numpy/__init__.cython-30.pxd":738
+/* "../../../../../tmp/pip-build-env-1f1oalyc/overlay/lib/python3.8/site-packages/numpy/__init__.cython-30.pxd":739
  * 
  * ctypedef npy_uint8      uint8_t
  * ctypedef npy_uint16     uint16_t             # <<<<<<<<<<<<<<
@@ -1604,7 +1604,7 @@ typedef npy_uint8 __pyx_t_5numpy_uint8_t;
  */
 typedef npy_uint16 __pyx_t_5numpy_uint16_t;
 
-/* "../../../../../tmp/pip-build-env-x4mieqja/overlay/lib/python3.12/site-packages/numpy/__init__.cython-30.pxd":739
+/* "../../../../../tmp/pip-build-env-1f1oalyc/overlay/lib/python3.8/site-packages/numpy/__init__.cython-30.pxd":740
  * ctypedef npy_uint8      uint8_t
  * ctypedef npy_uint16     uint16_t
  * ctypedef npy_uint32     uint32_t             # <<<<<<<<<<<<<<
@@ -1613,7 +1613,7 @@ typedef npy_uint16 __pyx_t_5numpy_uint16_t;
  */
 typedef npy_uint32 __pyx_t_5numpy_uint32_t;
 
-/* "../../../../../tmp/pip-build-env-x4mieqja/overlay/lib/python3.12/site-packages/numpy/__init__.cython-30.pxd":740
+/* "../../../../../tmp/pip-build-env-1f1oalyc/overlay/lib/python3.8/site-packages/numpy/__init__.cython-30.pxd":741
  * ctypedef npy_uint16     uint16_t
  * ctypedef npy_uint32     uint32_t
  * ctypedef npy_uint64     uint64_t             # <<<<<<<<<<<<<<
@@ -1622,7 +1622,7 @@ typedef npy_uint32 __pyx_t_5numpy_uint32_t;
  */
 typedef npy_uint64 __pyx_t_5numpy_uint64_t;
 
-/* "../../../../../tmp/pip-build-env-x4mieqja/overlay/lib/python3.12/site-packages/numpy/__init__.cython-30.pxd":744
+/* "../../../../../tmp/pip-build-env-1f1oalyc/overlay/lib/python3.8/site-packages/numpy/__init__.cython-30.pxd":745
  * #ctypedef npy_uint128    uint128_t
  * 
  * ctypedef npy_float32    float32_t             # <<<<<<<<<<<<<<
@@ -1631,7 +1631,7 @@ typedef npy_uint64 __pyx_t_5numpy_uint64_t;
  */
 typedef npy_float32 __pyx_t_5numpy_float32_t;
 
-/* "../../../../../tmp/pip-build-env-x4mieqja/overlay/lib/python3.12/site-packages/numpy/__init__.cython-30.pxd":745
+/* "../../../../../tmp/pip-build-env-1f1oalyc/overlay/lib/python3.8/site-packages/numpy/__init__.cython-30.pxd":746
  * 
  * ctypedef npy_float32    float32_t
  * ctypedef npy_float64    float64_t             # <<<<<<<<<<<<<<
@@ -1640,43 +1640,61 @@ typedef npy_float32 __pyx_t_5numpy_float32_t;
  */
 typedef npy_float64 __pyx_t_5numpy_float64_t;
 
-/* "../../../../../tmp/pip-build-env-x4mieqja/overlay/lib/python3.12/site-packages/numpy/__init__.cython-30.pxd":754
+/* "../../../../../tmp/pip-build-env-1f1oalyc/overlay/lib/python3.8/site-packages/numpy/__init__.cython-30.pxd":755
  * # The int types are mapped a bit surprising --
  * # numpy.int corresponds to 'l' and numpy.long to 'q'
  * ctypedef npy_long       int_t             # <<<<<<<<<<<<<<
+ * ctypedef npy_longlong   long_t
  * ctypedef npy_longlong   longlong_t
- * 
  */
 typedef npy_long __pyx_t_5numpy_int_t;
 
-/* "../../../../../tmp/pip-build-env-x4mieqja/overlay/lib/python3.12/site-packages/numpy/__init__.cython-30.pxd":755
+/* "../../../../../tmp/pip-build-env-1f1oalyc/overlay/lib/python3.8/site-packages/numpy/__init__.cython-30.pxd":756
  * # numpy.int corresponds to 'l' and numpy.long to 'q'
  * ctypedef npy_long       int_t
+ * ctypedef npy_longlong   long_t             # <<<<<<<<<<<<<<
+ * ctypedef npy_longlong   longlong_t
+ * 
+ */
+typedef npy_longlong __pyx_t_5numpy_long_t;
+
+/* "../../../../../tmp/pip-build-env-1f1oalyc/overlay/lib/python3.8/site-packages/numpy/__init__.cython-30.pxd":757
+ * ctypedef npy_long       int_t
+ * ctypedef npy_longlong   long_t
  * ctypedef npy_longlong   longlong_t             # <<<<<<<<<<<<<<
  * 
  * ctypedef npy_ulong      uint_t
  */
 typedef npy_longlong __pyx_t_5numpy_longlong_t;
 
-/* "../../../../../tmp/pip-build-env-x4mieqja/overlay/lib/python3.12/site-packages/numpy/__init__.cython-30.pxd":757
+/* "../../../../../tmp/pip-build-env-1f1oalyc/overlay/lib/python3.8/site-packages/numpy/__init__.cython-30.pxd":759
  * ctypedef npy_longlong   longlong_t
  * 
  * ctypedef npy_ulong      uint_t             # <<<<<<<<<<<<<<
+ * ctypedef npy_ulonglong  ulong_t
  * ctypedef npy_ulonglong  ulonglong_t
- * 
  */
 typedef npy_ulong __pyx_t_5numpy_uint_t;
 
-/* "../../../../../tmp/pip-build-env-x4mieqja/overlay/lib/python3.12/site-packages/numpy/__init__.cython-30.pxd":758
+/* "../../../../../tmp/pip-build-env-1f1oalyc/overlay/lib/python3.8/site-packages/numpy/__init__.cython-30.pxd":760
  * 
  * ctypedef npy_ulong      uint_t
+ * ctypedef npy_ulonglong  ulong_t             # <<<<<<<<<<<<<<
+ * ctypedef npy_ulonglong  ulonglong_t
+ * 
+ */
+typedef npy_ulonglong __pyx_t_5numpy_ulong_t;
+
+/* "../../../../../tmp/pip-build-env-1f1oalyc/overlay/lib/python3.8/site-packages/numpy/__init__.cython-30.pxd":761
+ * ctypedef npy_ulong      uint_t
+ * ctypedef npy_ulonglong  ulong_t
  * ctypedef npy_ulonglong  ulonglong_t             # <<<<<<<<<<<<<<
  * 
  * ctypedef npy_intp       intp_t
  */
 typedef npy_ulonglong __pyx_t_5numpy_ulonglong_t;
 
-/* "../../../../../tmp/pip-build-env-x4mieqja/overlay/lib/python3.12/site-packages/numpy/__init__.cython-30.pxd":760
+/* "../../../../../tmp/pip-build-env-1f1oalyc/overlay/lib/python3.8/site-packages/numpy/__init__.cython-30.pxd":763
  * ctypedef npy_ulonglong  ulonglong_t
  * 
  * ctypedef npy_intp       intp_t             # <<<<<<<<<<<<<<
@@ -1685,7 +1703,7 @@ typedef npy_ulonglong __pyx_t_5numpy_ulonglong_t;
  */
 typedef npy_intp __pyx_t_5numpy_intp_t;
 
-/* "../../../../../tmp/pip-build-env-x4mieqja/overlay/lib/python3.12/site-packages/numpy/__init__.cython-30.pxd":761
+/* "../../../../../tmp/pip-build-env-1f1oalyc/overlay/lib/python3.8/site-packages/numpy/__init__.cython-30.pxd":764
  * 
  * ctypedef npy_intp       intp_t
  * ctypedef npy_uintp      uintp_t             # <<<<<<<<<<<<<<
@@ -1694,7 +1712,7 @@ typedef npy_intp __pyx_t_5numpy_intp_t;
  */
 typedef npy_uintp __pyx_t_5numpy_uintp_t;
 
-/* "../../../../../tmp/pip-build-env-x4mieqja/overlay/lib/python3.12/site-packages/numpy/__init__.cython-30.pxd":763
+/* "../../../../../tmp/pip-build-env-1f1oalyc/overlay/lib/python3.8/site-packages/numpy/__init__.cython-30.pxd":766
  * ctypedef npy_uintp      uintp_t
  * 
  * ctypedef npy_double     float_t             # <<<<<<<<<<<<<<
@@ -1703,7 +1721,7 @@ typedef npy_uintp __pyx_t_5numpy_uintp_t;
  */
 typedef npy_double __pyx_t_5numpy_float_t;
 
-/* "../../../../../tmp/pip-build-env-x4mieqja/overlay/lib/python3.12/site-packages/numpy/__init__.cython-30.pxd":764
+/* "../../../../../tmp/pip-build-env-1f1oalyc/overlay/lib/python3.8/site-packages/numpy/__init__.cython-30.pxd":767
  * 
  * ctypedef npy_double     float_t
  * ctypedef npy_double     double_t             # <<<<<<<<<<<<<<
@@ -1712,7 +1730,7 @@ typedef npy_double __pyx_t_5numpy_float_t;
  */
 typedef npy_double __pyx_t_5numpy_double_t;
 
-/* "../../../../../tmp/pip-build-env-x4mieqja/overlay/lib/python3.12/site-packages/numpy/__init__.cython-30.pxd":765
+/* "../../../../../tmp/pip-build-env-1f1oalyc/overlay/lib/python3.8/site-packages/numpy/__init__.cython-30.pxd":768
  * ctypedef npy_double     float_t
  * ctypedef npy_double     double_t
  * ctypedef npy_longdouble longdouble_t             # <<<<<<<<<<<<<<
@@ -1749,7 +1767,7 @@ static CYTHON_INLINE __pyx_t_double_complex __pyx_t_double_complex_from_parts(do
 
 /*--- Type declarations ---*/
 
-/* "../../../../../tmp/pip-build-env-x4mieqja/overlay/lib/python3.12/site-packages/numpy/__init__.cython-30.pxd":767
+/* "../../../../../tmp/pip-build-env-1f1oalyc/overlay/lib/python3.8/site-packages/numpy/__init__.cython-30.pxd":770
  * ctypedef npy_longdouble longdouble_t
  * 
  * ctypedef npy_cfloat      cfloat_t             # <<<<<<<<<<<<<<
@@ -1758,7 +1776,7 @@ static CYTHON_INLINE __pyx_t_double_complex __pyx_t_double_complex_from_parts(do
  */
 typedef npy_cfloat __pyx_t_5numpy_cfloat_t;
 
-/* "../../../../../tmp/pip-build-env-x4mieqja/overlay/lib/python3.12/site-packages/numpy/__init__.cython-30.pxd":768
+/* "../../../../../tmp/pip-build-env-1f1oalyc/overlay/lib/python3.8/site-packages/numpy/__init__.cython-30.pxd":771
  * 
  * ctypedef npy_cfloat      cfloat_t
  * ctypedef npy_cdouble     cdouble_t             # <<<<<<<<<<<<<<
@@ -1767,7 +1785,7 @@ typedef npy_cfloat __pyx_t_5numpy_cfloat_t;
  */
 typedef npy_cdouble __pyx_t_5numpy_cdouble_t;
 
-/* "../../../../../tmp/pip-build-env-x4mieqja/overlay/lib/python3.12/site-packages/numpy/__init__.cython-30.pxd":769
+/* "../../../../../tmp/pip-build-env-1f1oalyc/overlay/lib/python3.8/site-packages/numpy/__init__.cython-30.pxd":772
  * ctypedef npy_cfloat      cfloat_t
  * ctypedef npy_cdouble     cdouble_t
  * ctypedef npy_clongdouble clongdouble_t             # <<<<<<<<<<<<<<
@@ -1776,7 +1794,7 @@ typedef npy_cdouble __pyx_t_5numpy_cdouble_t;
  */
 typedef npy_clongdouble __pyx_t_5numpy_clongdouble_t;
 
-/* "../../../../../tmp/pip-build-env-x4mieqja/overlay/lib/python3.12/site-packages/numpy/__init__.cython-30.pxd":771
+/* "../../../../../tmp/pip-build-env-1f1oalyc/overlay/lib/python3.8/site-packages/numpy/__init__.cython-30.pxd":774
  * ctypedef npy_clongdouble clongdouble_t
  * 
  * ctypedef npy_cdouble     complex_t             # <<<<<<<<<<<<<<
@@ -3369,7 +3387,7 @@ static int __pyx_m_traverse(PyObject *m, visitproc visit, void *arg) {
 #define __pyx_codeobj__11 __pyx_mstate_global->__pyx_codeobj__11
 /* #### Code section: module_code ### */
 
-/* "../../../../../tmp/pip-build-env-x4mieqja/overlay/lib/python3.12/site-packages/numpy/__init__.cython-30.pxd":245
+/* "../../../../../tmp/pip-build-env-1f1oalyc/overlay/lib/python3.8/site-packages/numpy/__init__.cython-30.pxd":245
  * 
  *         @property
  *         cdef inline PyObject* base(self) nogil:             # <<<<<<<<<<<<<<
@@ -3380,7 +3398,7 @@ static int __pyx_m_traverse(PyObject *m, visitproc visit, void *arg) {
 static CYTHON_INLINE PyObject *__pyx_f_5numpy_7ndarray_4base_base(PyArrayObject *__pyx_v_self) {
   PyObject *__pyx_r;
 
-  /* "../../../../../tmp/pip-build-env-x4mieqja/overlay/lib/python3.12/site-packages/numpy/__init__.cython-30.pxd":248
+  /* "../../../../../tmp/pip-build-env-1f1oalyc/overlay/lib/python3.8/site-packages/numpy/__init__.cython-30.pxd":248
  *             """Returns a borrowed reference to the object owning the data/memory.
  *             """
  *             return PyArray_BASE(self)             # <<<<<<<<<<<<<<
@@ -3390,7 +3408,7 @@ static CYTHON_INLINE PyObject *__pyx_f_5numpy_7ndarray_4base_base(PyArrayObject 
   __pyx_r = PyArray_BASE(__pyx_v_self);
   goto __pyx_L0;
 
-  /* "../../../../../tmp/pip-build-env-x4mieqja/overlay/lib/python3.12/site-packages/numpy/__init__.cython-30.pxd":245
+  /* "../../../../../tmp/pip-build-env-1f1oalyc/overlay/lib/python3.8/site-packages/numpy/__init__.cython-30.pxd":245
  * 
  *         @property
  *         cdef inline PyObject* base(self) nogil:             # <<<<<<<<<<<<<<
@@ -3403,7 +3421,7 @@ static CYTHON_INLINE PyObject *__pyx_f_5numpy_7ndarray_4base_base(PyArrayObject 
   return __pyx_r;
 }
 
-/* "../../../../../tmp/pip-build-env-x4mieqja/overlay/lib/python3.12/site-packages/numpy/__init__.cython-30.pxd":251
+/* "../../../../../tmp/pip-build-env-1f1oalyc/overlay/lib/python3.8/site-packages/numpy/__init__.cython-30.pxd":251
  * 
  *         @property
  *         cdef inline dtype descr(self):             # <<<<<<<<<<<<<<
@@ -3417,7 +3435,7 @@ static CYTHON_INLINE PyArray_Descr *__pyx_f_5numpy_7ndarray_5descr_descr(PyArray
   PyArray_Descr *__pyx_t_1;
   __Pyx_RefNannySetupContext("descr", 1);
 
-  /* "../../../../../tmp/pip-build-env-x4mieqja/overlay/lib/python3.12/site-packages/numpy/__init__.cython-30.pxd":254
+  /* "../../../../../tmp/pip-build-env-1f1oalyc/overlay/lib/python3.8/site-packages/numpy/__init__.cython-30.pxd":254
  *             """Returns an owned reference to the dtype of the array.
  *             """
  *             return <dtype>PyArray_DESCR(self)             # <<<<<<<<<<<<<<
@@ -3430,7 +3448,7 @@ static CYTHON_INLINE PyArray_Descr *__pyx_f_5numpy_7ndarray_5descr_descr(PyArray
   __pyx_r = ((PyArray_Descr *)__pyx_t_1);
   goto __pyx_L0;
 
-  /* "../../../../../tmp/pip-build-env-x4mieqja/overlay/lib/python3.12/site-packages/numpy/__init__.cython-30.pxd":251
+  /* "../../../../../tmp/pip-build-env-1f1oalyc/overlay/lib/python3.8/site-packages/numpy/__init__.cython-30.pxd":251
  * 
  *         @property
  *         cdef inline dtype descr(self):             # <<<<<<<<<<<<<<
@@ -3445,7 +3463,7 @@ static CYTHON_INLINE PyArray_Descr *__pyx_f_5numpy_7ndarray_5descr_descr(PyArray
   return __pyx_r;
 }
 
-/* "../../../../../tmp/pip-build-env-x4mieqja/overlay/lib/python3.12/site-packages/numpy/__init__.cython-30.pxd":257
+/* "../../../../../tmp/pip-build-env-1f1oalyc/overlay/lib/python3.8/site-packages/numpy/__init__.cython-30.pxd":257
  * 
  *         @property
  *         cdef inline int ndim(self) nogil:             # <<<<<<<<<<<<<<
@@ -3456,7 +3474,7 @@ static CYTHON_INLINE PyArray_Descr *__pyx_f_5numpy_7ndarray_5descr_descr(PyArray
 static CYTHON_INLINE int __pyx_f_5numpy_7ndarray_4ndim_ndim(PyArrayObject *__pyx_v_self) {
   int __pyx_r;
 
-  /* "../../../../../tmp/pip-build-env-x4mieqja/overlay/lib/python3.12/site-packages/numpy/__init__.cython-30.pxd":260
+  /* "../../../../../tmp/pip-build-env-1f1oalyc/overlay/lib/python3.8/site-packages/numpy/__init__.cython-30.pxd":260
  *             """Returns the number of dimensions in the array.
  *             """
  *             return PyArray_NDIM(self)             # <<<<<<<<<<<<<<
@@ -3466,7 +3484,7 @@ static CYTHON_INLINE int __pyx_f_5numpy_7ndarray_4ndim_ndim(PyArrayObject *__pyx
   __pyx_r = PyArray_NDIM(__pyx_v_self);
   goto __pyx_L0;
 
-  /* "../../../../../tmp/pip-build-env-x4mieqja/overlay/lib/python3.12/site-packages/numpy/__init__.cython-30.pxd":257
+  /* "../../../../../tmp/pip-build-env-1f1oalyc/overlay/lib/python3.8/site-packages/numpy/__init__.cython-30.pxd":257
  * 
  *         @property
  *         cdef inline int ndim(self) nogil:             # <<<<<<<<<<<<<<
@@ -3479,7 +3497,7 @@ static CYTHON_INLINE int __pyx_f_5numpy_7ndarray_4ndim_ndim(PyArrayObject *__pyx
   return __pyx_r;
 }
 
-/* "../../../../../tmp/pip-build-env-x4mieqja/overlay/lib/python3.12/site-packages/numpy/__init__.cython-30.pxd":263
+/* "../../../../../tmp/pip-build-env-1f1oalyc/overlay/lib/python3.8/site-packages/numpy/__init__.cython-30.pxd":263
  * 
  *         @property
  *         cdef inline npy_intp *shape(self) nogil:             # <<<<<<<<<<<<<<
@@ -3490,7 +3508,7 @@ static CYTHON_INLINE int __pyx_f_5numpy_7ndarray_4ndim_ndim(PyArrayObject *__pyx
 static CYTHON_INLINE npy_intp *__pyx_f_5numpy_7ndarray_5shape_shape(PyArrayObject *__pyx_v_self) {
   npy_intp *__pyx_r;
 
-  /* "../../../../../tmp/pip-build-env-x4mieqja/overlay/lib/python3.12/site-packages/numpy/__init__.cython-30.pxd":268
+  /* "../../../../../tmp/pip-build-env-1f1oalyc/overlay/lib/python3.8/site-packages/numpy/__init__.cython-30.pxd":268
  *             Can return NULL for 0-dimensional arrays.
  *             """
  *             return PyArray_DIMS(self)             # <<<<<<<<<<<<<<
@@ -3500,7 +3518,7 @@ static CYTHON_INLINE npy_intp *__pyx_f_5numpy_7ndarray_5shape_shape(PyArrayObjec
   __pyx_r = PyArray_DIMS(__pyx_v_self);
   goto __pyx_L0;
 
-  /* "../../../../../tmp/pip-build-env-x4mieqja/overlay/lib/python3.12/site-packages/numpy/__init__.cython-30.pxd":263
+  /* "../../../../../tmp/pip-build-env-1f1oalyc/overlay/lib/python3.8/site-packages/numpy/__init__.cython-30.pxd":263
  * 
  *         @property
  *         cdef inline npy_intp *shape(self) nogil:             # <<<<<<<<<<<<<<
@@ -3513,7 +3531,7 @@ static CYTHON_INLINE npy_intp *__pyx_f_5numpy_7ndarray_5shape_shape(PyArrayObjec
   return __pyx_r;
 }
 
-/* "../../../../../tmp/pip-build-env-x4mieqja/overlay/lib/python3.12/site-packages/numpy/__init__.cython-30.pxd":271
+/* "../../../../../tmp/pip-build-env-1f1oalyc/overlay/lib/python3.8/site-packages/numpy/__init__.cython-30.pxd":271
  * 
  *         @property
  *         cdef inline npy_intp *strides(self) nogil:             # <<<<<<<<<<<<<<
@@ -3524,7 +3542,7 @@ static CYTHON_INLINE npy_intp *__pyx_f_5numpy_7ndarray_5shape_shape(PyArrayObjec
 static CYTHON_INLINE npy_intp *__pyx_f_5numpy_7ndarray_7strides_strides(PyArrayObject *__pyx_v_self) {
   npy_intp *__pyx_r;
 
-  /* "../../../../../tmp/pip-build-env-x4mieqja/overlay/lib/python3.12/site-packages/numpy/__init__.cython-30.pxd":275
+  /* "../../../../../tmp/pip-build-env-1f1oalyc/overlay/lib/python3.8/site-packages/numpy/__init__.cython-30.pxd":275
  *             The number of elements matches the number of dimensions of the array (ndim).
  *             """
  *             return PyArray_STRIDES(self)             # <<<<<<<<<<<<<<
@@ -3534,7 +3552,7 @@ static CYTHON_INLINE npy_intp *__pyx_f_5numpy_7ndarray_7strides_strides(PyArrayO
   __pyx_r = PyArray_STRIDES(__pyx_v_self);
   goto __pyx_L0;
 
-  /* "../../../../../tmp/pip-build-env-x4mieqja/overlay/lib/python3.12/site-packages/numpy/__init__.cython-30.pxd":271
+  /* "../../../../../tmp/pip-build-env-1f1oalyc/overlay/lib/python3.8/site-packages/numpy/__init__.cython-30.pxd":271
  * 
  *         @property
  *         cdef inline npy_intp *strides(self) nogil:             # <<<<<<<<<<<<<<
@@ -3547,7 +3565,7 @@ static CYTHON_INLINE npy_intp *__pyx_f_5numpy_7ndarray_7strides_strides(PyArrayO
   return __pyx_r;
 }
 
-/* "../../../../../tmp/pip-build-env-x4mieqja/overlay/lib/python3.12/site-packages/numpy/__init__.cython-30.pxd":278
+/* "../../../../../tmp/pip-build-env-1f1oalyc/overlay/lib/python3.8/site-packages/numpy/__init__.cython-30.pxd":278
  * 
  *         @property
  *         cdef inline npy_intp size(self) nogil:             # <<<<<<<<<<<<<<
@@ -3558,7 +3576,7 @@ static CYTHON_INLINE npy_intp *__pyx_f_5numpy_7ndarray_7strides_strides(PyArrayO
 static CYTHON_INLINE npy_intp __pyx_f_5numpy_7ndarray_4size_size(PyArrayObject *__pyx_v_self) {
   npy_intp __pyx_r;
 
-  /* "../../../../../tmp/pip-build-env-x4mieqja/overlay/lib/python3.12/site-packages/numpy/__init__.cython-30.pxd":281
+  /* "../../../../../tmp/pip-build-env-1f1oalyc/overlay/lib/python3.8/site-packages/numpy/__init__.cython-30.pxd":281
  *             """Returns the total size (in number of elements) of the array.
  *             """
  *             return PyArray_SIZE(self)             # <<<<<<<<<<<<<<
@@ -3568,7 +3586,7 @@ static CYTHON_INLINE npy_intp __pyx_f_5numpy_7ndarray_4size_size(PyArrayObject *
   __pyx_r = PyArray_SIZE(__pyx_v_self);
   goto __pyx_L0;
 
-  /* "../../../../../tmp/pip-build-env-x4mieqja/overlay/lib/python3.12/site-packages/numpy/__init__.cython-30.pxd":278
+  /* "../../../../../tmp/pip-build-env-1f1oalyc/overlay/lib/python3.8/site-packages/numpy/__init__.cython-30.pxd":278
  * 
  *         @property
  *         cdef inline npy_intp size(self) nogil:             # <<<<<<<<<<<<<<
@@ -3581,7 +3599,7 @@ static CYTHON_INLINE npy_intp __pyx_f_5numpy_7ndarray_4size_size(PyArrayObject *
   return __pyx_r;
 }
 
-/* "../../../../../tmp/pip-build-env-x4mieqja/overlay/lib/python3.12/site-packages/numpy/__init__.cython-30.pxd":284
+/* "../../../../../tmp/pip-build-env-1f1oalyc/overlay/lib/python3.8/site-packages/numpy/__init__.cython-30.pxd":284
  * 
  *         @property
  *         cdef inline char* data(self) nogil:             # <<<<<<<<<<<<<<
@@ -3592,7 +3610,7 @@ static CYTHON_INLINE npy_intp __pyx_f_5numpy_7ndarray_4size_size(PyArrayObject *
 static CYTHON_INLINE char *__pyx_f_5numpy_7ndarray_4data_data(PyArrayObject *__pyx_v_self) {
   char *__pyx_r;
 
-  /* "../../../../../tmp/pip-build-env-x4mieqja/overlay/lib/python3.12/site-packages/numpy/__init__.cython-30.pxd":290
+  /* "../../../../../tmp/pip-build-env-1f1oalyc/overlay/lib/python3.8/site-packages/numpy/__init__.cython-30.pxd":290
  *             of `PyArray_DATA()` instead, which returns a 'void*'.
  *             """
  *             return PyArray_BYTES(self)             # <<<<<<<<<<<<<<
@@ -3602,7 +3620,7 @@ static CYTHON_INLINE char *__pyx_f_5numpy_7ndarray_4data_data(PyArrayObject *__p
   __pyx_r = PyArray_BYTES(__pyx_v_self);
   goto __pyx_L0;
 
-  /* "../../../../../tmp/pip-build-env-x4mieqja/overlay/lib/python3.12/site-packages/numpy/__init__.cython-30.pxd":284
+  /* "../../../../../tmp/pip-build-env-1f1oalyc/overlay/lib/python3.8/site-packages/numpy/__init__.cython-30.pxd":284
  * 
  *         @property
  *         cdef inline char* data(self) nogil:             # <<<<<<<<<<<<<<
@@ -3615,7 +3633,7 @@ static CYTHON_INLINE char *__pyx_f_5numpy_7ndarray_4data_data(PyArrayObject *__p
   return __pyx_r;
 }
 
-/* "../../../../../tmp/pip-build-env-x4mieqja/overlay/lib/python3.12/site-packages/numpy/__init__.cython-30.pxd":773
+/* "../../../../../tmp/pip-build-env-1f1oalyc/overlay/lib/python3.8/site-packages/numpy/__init__.cython-30.pxd":776
  * ctypedef npy_cdouble     complex_t
  * 
  * cdef inline object PyArray_MultiIterNew1(a):             # <<<<<<<<<<<<<<
@@ -3632,7 +3650,7 @@ static CYTHON_INLINE PyObject *__pyx_f_5numpy_PyArray_MultiIterNew1(PyObject *__
   int __pyx_clineno = 0;
   __Pyx_RefNannySetupContext("PyArray_MultiIterNew1", 1);
 
-  /* "../../../../../tmp/pip-build-env-x4mieqja/overlay/lib/python3.12/site-packages/numpy/__init__.cython-30.pxd":774
+  /* "../../../../../tmp/pip-build-env-1f1oalyc/overlay/lib/python3.8/site-packages/numpy/__init__.cython-30.pxd":777
  * 
  * cdef inline object PyArray_MultiIterNew1(a):
  *     return PyArray_MultiIterNew(1, <void*>a)             # <<<<<<<<<<<<<<
@@ -3640,13 +3658,13 @@ static CYTHON_INLINE PyObject *__pyx_f_5numpy_PyArray_MultiIterNew1(PyObject *__
  * cdef inline object PyArray_MultiIterNew2(a, b):
  */
   __Pyx_XDECREF(__pyx_r);
-  __pyx_t_1 = PyArray_MultiIterNew(1, ((void *)__pyx_v_a)); if (unlikely(!__pyx_t_1)) __PYX_ERR(1, 774, __pyx_L1_error)
+  __pyx_t_1 = PyArray_MultiIterNew(1, ((void *)__pyx_v_a)); if (unlikely(!__pyx_t_1)) __PYX_ERR(1, 777, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __pyx_r = __pyx_t_1;
   __pyx_t_1 = 0;
   goto __pyx_L0;
 
-  /* "../../../../../tmp/pip-build-env-x4mieqja/overlay/lib/python3.12/site-packages/numpy/__init__.cython-30.pxd":773
+  /* "../../../../../tmp/pip-build-env-1f1oalyc/overlay/lib/python3.8/site-packages/numpy/__init__.cython-30.pxd":776
  * ctypedef npy_cdouble     complex_t
  * 
  * cdef inline object PyArray_MultiIterNew1(a):             # <<<<<<<<<<<<<<
@@ -3665,7 +3683,7 @@ static CYTHON_INLINE PyObject *__pyx_f_5numpy_PyArray_MultiIterNew1(PyObject *__
   return __pyx_r;
 }
 
-/* "../../../../../tmp/pip-build-env-x4mieqja/overlay/lib/python3.12/site-packages/numpy/__init__.cython-30.pxd":776
+/* "../../../../../tmp/pip-build-env-1f1oalyc/overlay/lib/python3.8/site-packages/numpy/__init__.cython-30.pxd":779
  *     return PyArray_MultiIterNew(1, <void*>a)
  * 
  * cdef inline object PyArray_MultiIterNew2(a, b):             # <<<<<<<<<<<<<<
@@ -3682,7 +3700,7 @@ static CYTHON_INLINE PyObject *__pyx_f_5numpy_PyArray_MultiIterNew2(PyObject *__
   int __pyx_clineno = 0;
   __Pyx_RefNannySetupContext("PyArray_MultiIterNew2", 1);
 
-  /* "../../../../../tmp/pip-build-env-x4mieqja/overlay/lib/python3.12/site-packages/numpy/__init__.cython-30.pxd":777
+  /* "../../../../../tmp/pip-build-env-1f1oalyc/overlay/lib/python3.8/site-packages/numpy/__init__.cython-30.pxd":780
  * 
  * cdef inline object PyArray_MultiIterNew2(a, b):
  *     return PyArray_MultiIterNew(2, <void*>a, <void*>b)             # <<<<<<<<<<<<<<
@@ -3690,13 +3708,13 @@ static CYTHON_INLINE PyObject *__pyx_f_5numpy_PyArray_MultiIterNew2(PyObject *__
  * cdef inline object PyArray_MultiIterNew3(a, b, c):
  */
   __Pyx_XDECREF(__pyx_r);
-  __pyx_t_1 = PyArray_MultiIterNew(2, ((void *)__pyx_v_a), ((void *)__pyx_v_b)); if (unlikely(!__pyx_t_1)) __PYX_ERR(1, 777, __pyx_L1_error)
+  __pyx_t_1 = PyArray_MultiIterNew(2, ((void *)__pyx_v_a), ((void *)__pyx_v_b)); if (unlikely(!__pyx_t_1)) __PYX_ERR(1, 780, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __pyx_r = __pyx_t_1;
   __pyx_t_1 = 0;
   goto __pyx_L0;
 
-  /* "../../../../../tmp/pip-build-env-x4mieqja/overlay/lib/python3.12/site-packages/numpy/__init__.cython-30.pxd":776
+  /* "../../../../../tmp/pip-build-env-1f1oalyc/overlay/lib/python3.8/site-packages/numpy/__init__.cython-30.pxd":779
  *     return PyArray_MultiIterNew(1, <void*>a)
  * 
  * cdef inline object PyArray_MultiIterNew2(a, b):             # <<<<<<<<<<<<<<
@@ -3715,7 +3733,7 @@ static CYTHON_INLINE PyObject *__pyx_f_5numpy_PyArray_MultiIterNew2(PyObject *__
   return __pyx_r;
 }
 
-/* "../../../../../tmp/pip-build-env-x4mieqja/overlay/lib/python3.12/site-packages/numpy/__init__.cython-30.pxd":779
+/* "../../../../../tmp/pip-build-env-1f1oalyc/overlay/lib/python3.8/site-packages/numpy/__init__.cython-30.pxd":782
  *     return PyArray_MultiIterNew(2, <void*>a, <void*>b)
  * 
  * cdef inline object PyArray_MultiIterNew3(a, b, c):             # <<<<<<<<<<<<<<
@@ -3732,7 +3750,7 @@ static CYTHON_INLINE PyObject *__pyx_f_5numpy_PyArray_MultiIterNew3(PyObject *__
   int __pyx_clineno = 0;
   __Pyx_RefNannySetupContext("PyArray_MultiIterNew3", 1);
 
-  /* "../../../../../tmp/pip-build-env-x4mieqja/overlay/lib/python3.12/site-packages/numpy/__init__.cython-30.pxd":780
+  /* "../../../../../tmp/pip-build-env-1f1oalyc/overlay/lib/python3.8/site-packages/numpy/__init__.cython-30.pxd":783
  * 
  * cdef inline object PyArray_MultiIterNew3(a, b, c):
  *     return PyArray_MultiIterNew(3, <void*>a, <void*>b, <void*> c)             # <<<<<<<<<<<<<<
@@ -3740,13 +3758,13 @@ static CYTHON_INLINE PyObject *__pyx_f_5numpy_PyArray_MultiIterNew3(PyObject *__
  * cdef inline object PyArray_MultiIterNew4(a, b, c, d):
  */
   __Pyx_XDECREF(__pyx_r);
-  __pyx_t_1 = PyArray_MultiIterNew(3, ((void *)__pyx_v_a), ((void *)__pyx_v_b), ((void *)__pyx_v_c)); if (unlikely(!__pyx_t_1)) __PYX_ERR(1, 780, __pyx_L1_error)
+  __pyx_t_1 = PyArray_MultiIterNew(3, ((void *)__pyx_v_a), ((void *)__pyx_v_b), ((void *)__pyx_v_c)); if (unlikely(!__pyx_t_1)) __PYX_ERR(1, 783, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __pyx_r = __pyx_t_1;
   __pyx_t_1 = 0;
   goto __pyx_L0;
 
-  /* "../../../../../tmp/pip-build-env-x4mieqja/overlay/lib/python3.12/site-packages/numpy/__init__.cython-30.pxd":779
+  /* "../../../../../tmp/pip-build-env-1f1oalyc/overlay/lib/python3.8/site-packages/numpy/__init__.cython-30.pxd":782
  *     return PyArray_MultiIterNew(2, <void*>a, <void*>b)
  * 
  * cdef inline object PyArray_MultiIterNew3(a, b, c):             # <<<<<<<<<<<<<<
@@ -3765,7 +3783,7 @@ static CYTHON_INLINE PyObject *__pyx_f_5numpy_PyArray_MultiIterNew3(PyObject *__
   return __pyx_r;
 }
 
-/* "../../../../../tmp/pip-build-env-x4mieqja/overlay/lib/python3.12/site-packages/numpy/__init__.cython-30.pxd":782
+/* "../../../../../tmp/pip-build-env-1f1oalyc/overlay/lib/python3.8/site-packages/numpy/__init__.cython-30.pxd":785
  *     return PyArray_MultiIterNew(3, <void*>a, <void*>b, <void*> c)
  * 
  * cdef inline object PyArray_MultiIterNew4(a, b, c, d):             # <<<<<<<<<<<<<<
@@ -3782,7 +3800,7 @@ static CYTHON_INLINE PyObject *__pyx_f_5numpy_PyArray_MultiIterNew4(PyObject *__
   int __pyx_clineno = 0;
   __Pyx_RefNannySetupContext("PyArray_MultiIterNew4", 1);
 
-  /* "../../../../../tmp/pip-build-env-x4mieqja/overlay/lib/python3.12/site-packages/numpy/__init__.cython-30.pxd":783
+  /* "../../../../../tmp/pip-build-env-1f1oalyc/overlay/lib/python3.8/site-packages/numpy/__init__.cython-30.pxd":786
  * 
  * cdef inline object PyArray_MultiIterNew4(a, b, c, d):
  *     return PyArray_MultiIterNew(4, <void*>a, <void*>b, <void*>c, <void*> d)             # <<<<<<<<<<<<<<
@@ -3790,13 +3808,13 @@ static CYTHON_INLINE PyObject *__pyx_f_5numpy_PyArray_MultiIterNew4(PyObject *__
  * cdef inline object PyArray_MultiIterNew5(a, b, c, d, e):
  */
   __Pyx_XDECREF(__pyx_r);
-  __pyx_t_1 = PyArray_MultiIterNew(4, ((void *)__pyx_v_a), ((void *)__pyx_v_b), ((void *)__pyx_v_c), ((void *)__pyx_v_d)); if (unlikely(!__pyx_t_1)) __PYX_ERR(1, 783, __pyx_L1_error)
+  __pyx_t_1 = PyArray_MultiIterNew(4, ((void *)__pyx_v_a), ((void *)__pyx_v_b), ((void *)__pyx_v_c), ((void *)__pyx_v_d)); if (unlikely(!__pyx_t_1)) __PYX_ERR(1, 786, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __pyx_r = __pyx_t_1;
   __pyx_t_1 = 0;
   goto __pyx_L0;
 
-  /* "../../../../../tmp/pip-build-env-x4mieqja/overlay/lib/python3.12/site-packages/numpy/__init__.cython-30.pxd":782
+  /* "../../../../../tmp/pip-build-env-1f1oalyc/overlay/lib/python3.8/site-packages/numpy/__init__.cython-30.pxd":785
  *     return PyArray_MultiIterNew(3, <void*>a, <void*>b, <void*> c)
  * 
  * cdef inline object PyArray_MultiIterNew4(a, b, c, d):             # <<<<<<<<<<<<<<
@@ -3815,7 +3833,7 @@ static CYTHON_INLINE PyObject *__pyx_f_5numpy_PyArray_MultiIterNew4(PyObject *__
   return __pyx_r;
 }
 
-/* "../../../../../tmp/pip-build-env-x4mieqja/overlay/lib/python3.12/site-packages/numpy/__init__.cython-30.pxd":785
+/* "../../../../../tmp/pip-build-env-1f1oalyc/overlay/lib/python3.8/site-packages/numpy/__init__.cython-30.pxd":788
  *     return PyArray_MultiIterNew(4, <void*>a, <void*>b, <void*>c, <void*> d)
  * 
  * cdef inline object PyArray_MultiIterNew5(a, b, c, d, e):             # <<<<<<<<<<<<<<
@@ -3832,7 +3850,7 @@ static CYTHON_INLINE PyObject *__pyx_f_5numpy_PyArray_MultiIterNew5(PyObject *__
   int __pyx_clineno = 0;
   __Pyx_RefNannySetupContext("PyArray_MultiIterNew5", 1);
 
-  /* "../../../../../tmp/pip-build-env-x4mieqja/overlay/lib/python3.12/site-packages/numpy/__init__.cython-30.pxd":786
+  /* "../../../../../tmp/pip-build-env-1f1oalyc/overlay/lib/python3.8/site-packages/numpy/__init__.cython-30.pxd":789
  * 
  * cdef inline object PyArray_MultiIterNew5(a, b, c, d, e):
  *     return PyArray_MultiIterNew(5, <void*>a, <void*>b, <void*>c, <void*> d, <void*> e)             # <<<<<<<<<<<<<<
@@ -3840,13 +3858,13 @@ static CYTHON_INLINE PyObject *__pyx_f_5numpy_PyArray_MultiIterNew5(PyObject *__
  * cdef inline tuple PyDataType_SHAPE(dtype d):
  */
   __Pyx_XDECREF(__pyx_r);
-  __pyx_t_1 = PyArray_MultiIterNew(5, ((void *)__pyx_v_a), ((void *)__pyx_v_b), ((void *)__pyx_v_c), ((void *)__pyx_v_d), ((void *)__pyx_v_e)); if (unlikely(!__pyx_t_1)) __PYX_ERR(1, 786, __pyx_L1_error)
+  __pyx_t_1 = PyArray_MultiIterNew(5, ((void *)__pyx_v_a), ((void *)__pyx_v_b), ((void *)__pyx_v_c), ((void *)__pyx_v_d), ((void *)__pyx_v_e)); if (unlikely(!__pyx_t_1)) __PYX_ERR(1, 789, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __pyx_r = __pyx_t_1;
   __pyx_t_1 = 0;
   goto __pyx_L0;
 
-  /* "../../../../../tmp/pip-build-env-x4mieqja/overlay/lib/python3.12/site-packages/numpy/__init__.cython-30.pxd":785
+  /* "../../../../../tmp/pip-build-env-1f1oalyc/overlay/lib/python3.8/site-packages/numpy/__init__.cython-30.pxd":788
  *     return PyArray_MultiIterNew(4, <void*>a, <void*>b, <void*>c, <void*> d)
  * 
  * cdef inline object PyArray_MultiIterNew5(a, b, c, d, e):             # <<<<<<<<<<<<<<
@@ -3865,7 +3883,7 @@ static CYTHON_INLINE PyObject *__pyx_f_5numpy_PyArray_MultiIterNew5(PyObject *__
   return __pyx_r;
 }
 
-/* "../../../../../tmp/pip-build-env-x4mieqja/overlay/lib/python3.12/site-packages/numpy/__init__.cython-30.pxd":788
+/* "../../../../../tmp/pip-build-env-1f1oalyc/overlay/lib/python3.8/site-packages/numpy/__init__.cython-30.pxd":791
  *     return PyArray_MultiIterNew(5, <void*>a, <void*>b, <void*>c, <void*> d, <void*> e)
  * 
  * cdef inline tuple PyDataType_SHAPE(dtype d):             # <<<<<<<<<<<<<<
@@ -3879,7 +3897,7 @@ static CYTHON_INLINE PyObject *__pyx_f_5numpy_PyDataType_SHAPE(PyArray_Descr *__
   int __pyx_t_1;
   __Pyx_RefNannySetupContext("PyDataType_SHAPE", 1);
 
-  /* "../../../../../tmp/pip-build-env-x4mieqja/overlay/lib/python3.12/site-packages/numpy/__init__.cython-30.pxd":789
+  /* "../../../../../tmp/pip-build-env-1f1oalyc/overlay/lib/python3.8/site-packages/numpy/__init__.cython-30.pxd":792
  * 
  * cdef inline tuple PyDataType_SHAPE(dtype d):
  *     if PyDataType_HASSUBARRAY(d):             # <<<<<<<<<<<<<<
@@ -3889,7 +3907,7 @@ static CYTHON_INLINE PyObject *__pyx_f_5numpy_PyDataType_SHAPE(PyArray_Descr *__
   __pyx_t_1 = PyDataType_HASSUBARRAY(__pyx_v_d);
   if (__pyx_t_1) {
 
-    /* "../../../../../tmp/pip-build-env-x4mieqja/overlay/lib/python3.12/site-packages/numpy/__init__.cython-30.pxd":790
+    /* "../../../../../tmp/pip-build-env-1f1oalyc/overlay/lib/python3.8/site-packages/numpy/__init__.cython-30.pxd":793
  * cdef inline tuple PyDataType_SHAPE(dtype d):
  *     if PyDataType_HASSUBARRAY(d):
  *         return <tuple>d.subarray.shape             # <<<<<<<<<<<<<<
@@ -3901,7 +3919,7 @@ static CYTHON_INLINE PyObject *__pyx_f_5numpy_PyDataType_SHAPE(PyArray_Descr *__
     __pyx_r = ((PyObject*)__pyx_v_d->subarray->shape);
     goto __pyx_L0;
 
-    /* "../../../../../tmp/pip-build-env-x4mieqja/overlay/lib/python3.12/site-packages/numpy/__init__.cython-30.pxd":789
+    /* "../../../../../tmp/pip-build-env-1f1oalyc/overlay/lib/python3.8/site-packages/numpy/__init__.cython-30.pxd":792
  * 
  * cdef inline tuple PyDataType_SHAPE(dtype d):
  *     if PyDataType_HASSUBARRAY(d):             # <<<<<<<<<<<<<<
@@ -3910,7 +3928,7 @@ static CYTHON_INLINE PyObject *__pyx_f_5numpy_PyDataType_SHAPE(PyArray_Descr *__
  */
   }
 
-  /* "../../../../../tmp/pip-build-env-x4mieqja/overlay/lib/python3.12/site-packages/numpy/__init__.cython-30.pxd":792
+  /* "../../../../../tmp/pip-build-env-1f1oalyc/overlay/lib/python3.8/site-packages/numpy/__init__.cython-30.pxd":795
  *         return <tuple>d.subarray.shape
  *     else:
  *         return ()             # <<<<<<<<<<<<<<
@@ -3924,7 +3942,7 @@ static CYTHON_INLINE PyObject *__pyx_f_5numpy_PyDataType_SHAPE(PyArray_Descr *__
     goto __pyx_L0;
   }
 
-  /* "../../../../../tmp/pip-build-env-x4mieqja/overlay/lib/python3.12/site-packages/numpy/__init__.cython-30.pxd":788
+  /* "../../../../../tmp/pip-build-env-1f1oalyc/overlay/lib/python3.8/site-packages/numpy/__init__.cython-30.pxd":791
  *     return PyArray_MultiIterNew(5, <void*>a, <void*>b, <void*>c, <void*> d, <void*> e)
  * 
  * cdef inline tuple PyDataType_SHAPE(dtype d):             # <<<<<<<<<<<<<<
@@ -3939,7 +3957,7 @@ static CYTHON_INLINE PyObject *__pyx_f_5numpy_PyDataType_SHAPE(PyArray_Descr *__
   return __pyx_r;
 }
 
-/* "../../../../../tmp/pip-build-env-x4mieqja/overlay/lib/python3.12/site-packages/numpy/__init__.cython-30.pxd":968
+/* "../../../../../tmp/pip-build-env-1f1oalyc/overlay/lib/python3.8/site-packages/numpy/__init__.cython-30.pxd":970
  *     int _import_umath() except -1
  * 
  * cdef inline void set_array_base(ndarray arr, object base):             # <<<<<<<<<<<<<<
@@ -3948,12 +3966,8 @@ static CYTHON_INLINE PyObject *__pyx_f_5numpy_PyDataType_SHAPE(PyArray_Descr *__
  */
 
 static CYTHON_INLINE void __pyx_f_5numpy_set_array_base(PyArrayObject *__pyx_v_arr, PyObject *__pyx_v_base) {
-  int __pyx_t_1;
-  int __pyx_lineno = 0;
-  const char *__pyx_filename = NULL;
-  int __pyx_clineno = 0;
 
-  /* "../../../../../tmp/pip-build-env-x4mieqja/overlay/lib/python3.12/site-packages/numpy/__init__.cython-30.pxd":969
+  /* "../../../../../tmp/pip-build-env-1f1oalyc/overlay/lib/python3.8/site-packages/numpy/__init__.cython-30.pxd":971
  * 
  * cdef inline void set_array_base(ndarray arr, object base):
  *     Py_INCREF(base) # important to do this before stealing the reference below!             # <<<<<<<<<<<<<<
@@ -3962,16 +3976,16 @@ static CYTHON_INLINE void __pyx_f_5numpy_set_array_base(PyArrayObject *__pyx_v_a
  */
   Py_INCREF(__pyx_v_base);
 
-  /* "../../../../../tmp/pip-build-env-x4mieqja/overlay/lib/python3.12/site-packages/numpy/__init__.cython-30.pxd":970
+  /* "../../../../../tmp/pip-build-env-1f1oalyc/overlay/lib/python3.8/site-packages/numpy/__init__.cython-30.pxd":972
  * cdef inline void set_array_base(ndarray arr, object base):
  *     Py_INCREF(base) # important to do this before stealing the reference below!
  *     PyArray_SetBaseObject(arr, base)             # <<<<<<<<<<<<<<
  * 
  * cdef inline object get_array_base(ndarray arr):
  */
-  __pyx_t_1 = PyArray_SetBaseObject(__pyx_v_arr, __pyx_v_base); if (unlikely(__pyx_t_1 == ((int)-1))) __PYX_ERR(1, 970, __pyx_L1_error)
+  (void)(PyArray_SetBaseObject(__pyx_v_arr, __pyx_v_base));
 
-  /* "../../../../../tmp/pip-build-env-x4mieqja/overlay/lib/python3.12/site-packages/numpy/__init__.cython-30.pxd":968
+  /* "../../../../../tmp/pip-build-env-1f1oalyc/overlay/lib/python3.8/site-packages/numpy/__init__.cython-30.pxd":970
  *     int _import_umath() except -1
  * 
  * cdef inline void set_array_base(ndarray arr, object base):             # <<<<<<<<<<<<<<
@@ -3980,13 +3994,9 @@ static CYTHON_INLINE void __pyx_f_5numpy_set_array_base(PyArrayObject *__pyx_v_a
  */
 
   /* function exit code */
-  goto __pyx_L0;
-  __pyx_L1_error:;
-  __Pyx_AddTraceback("numpy.set_array_base", __pyx_clineno, __pyx_lineno, __pyx_filename);
-  __pyx_L0:;
 }
 
-/* "../../../../../tmp/pip-build-env-x4mieqja/overlay/lib/python3.12/site-packages/numpy/__init__.cython-30.pxd":972
+/* "../../../../../tmp/pip-build-env-1f1oalyc/overlay/lib/python3.8/site-packages/numpy/__init__.cython-30.pxd":974
  *     PyArray_SetBaseObject(arr, base)
  * 
  * cdef inline object get_array_base(ndarray arr):             # <<<<<<<<<<<<<<
@@ -4001,7 +4011,7 @@ static CYTHON_INLINE PyObject *__pyx_f_5numpy_get_array_base(PyArrayObject *__py
   int __pyx_t_1;
   __Pyx_RefNannySetupContext("get_array_base", 1);
 
-  /* "../../../../../tmp/pip-build-env-x4mieqja/overlay/lib/python3.12/site-packages/numpy/__init__.cython-30.pxd":973
+  /* "../../../../../tmp/pip-build-env-1f1oalyc/overlay/lib/python3.8/site-packages/numpy/__init__.cython-30.pxd":975
  * 
  * cdef inline object get_array_base(ndarray arr):
  *     base = PyArray_BASE(arr)             # <<<<<<<<<<<<<<
@@ -4010,7 +4020,7 @@ static CYTHON_INLINE PyObject *__pyx_f_5numpy_get_array_base(PyArrayObject *__py
  */
   __pyx_v_base = PyArray_BASE(__pyx_v_arr);
 
-  /* "../../../../../tmp/pip-build-env-x4mieqja/overlay/lib/python3.12/site-packages/numpy/__init__.cython-30.pxd":974
+  /* "../../../../../tmp/pip-build-env-1f1oalyc/overlay/lib/python3.8/site-packages/numpy/__init__.cython-30.pxd":976
  * cdef inline object get_array_base(ndarray arr):
  *     base = PyArray_BASE(arr)
  *     if base is NULL:             # <<<<<<<<<<<<<<
@@ -4020,7 +4030,7 @@ static CYTHON_INLINE PyObject *__pyx_f_5numpy_get_array_base(PyArrayObject *__py
   __pyx_t_1 = (__pyx_v_base == NULL);
   if (__pyx_t_1) {
 
-    /* "../../../../../tmp/pip-build-env-x4mieqja/overlay/lib/python3.12/site-packages/numpy/__init__.cython-30.pxd":975
+    /* "../../../../../tmp/pip-build-env-1f1oalyc/overlay/lib/python3.8/site-packages/numpy/__init__.cython-30.pxd":977
  *     base = PyArray_BASE(arr)
  *     if base is NULL:
  *         return None             # <<<<<<<<<<<<<<
@@ -4031,7 +4041,7 @@ static CYTHON_INLINE PyObject *__pyx_f_5numpy_get_array_base(PyArrayObject *__py
     __pyx_r = Py_None; __Pyx_INCREF(Py_None);
     goto __pyx_L0;
 
-    /* "../../../../../tmp/pip-build-env-x4mieqja/overlay/lib/python3.12/site-packages/numpy/__init__.cython-30.pxd":974
+    /* "../../../../../tmp/pip-build-env-1f1oalyc/overlay/lib/python3.8/site-packages/numpy/__init__.cython-30.pxd":976
  * cdef inline object get_array_base(ndarray arr):
  *     base = PyArray_BASE(arr)
  *     if base is NULL:             # <<<<<<<<<<<<<<
@@ -4040,7 +4050,7 @@ static CYTHON_INLINE PyObject *__pyx_f_5numpy_get_array_base(PyArrayObject *__py
  */
   }
 
-  /* "../../../../../tmp/pip-build-env-x4mieqja/overlay/lib/python3.12/site-packages/numpy/__init__.cython-30.pxd":976
+  /* "../../../../../tmp/pip-build-env-1f1oalyc/overlay/lib/python3.8/site-packages/numpy/__init__.cython-30.pxd":978
  *     if base is NULL:
  *         return None
  *     return <object>base             # <<<<<<<<<<<<<<
@@ -4052,7 +4062,7 @@ static CYTHON_INLINE PyObject *__pyx_f_5numpy_get_array_base(PyArrayObject *__py
   __pyx_r = ((PyObject *)__pyx_v_base);
   goto __pyx_L0;
 
-  /* "../../../../../tmp/pip-build-env-x4mieqja/overlay/lib/python3.12/site-packages/numpy/__init__.cython-30.pxd":972
+  /* "../../../../../tmp/pip-build-env-1f1oalyc/overlay/lib/python3.8/site-packages/numpy/__init__.cython-30.pxd":974
  *     PyArray_SetBaseObject(arr, base)
  * 
  * cdef inline object get_array_base(ndarray arr):             # <<<<<<<<<<<<<<
@@ -4067,7 +4077,7 @@ static CYTHON_INLINE PyObject *__pyx_f_5numpy_get_array_base(PyArrayObject *__py
   return __pyx_r;
 }
 
-/* "../../../../../tmp/pip-build-env-x4mieqja/overlay/lib/python3.12/site-packages/numpy/__init__.cython-30.pxd":980
+/* "../../../../../tmp/pip-build-env-1f1oalyc/overlay/lib/python3.8/site-packages/numpy/__init__.cython-30.pxd":982
  * # Versions of the import_* functions which are more suitable for
  * # Cython code.
  * cdef inline int import_array() except -1:             # <<<<<<<<<<<<<<
@@ -4091,7 +4101,7 @@ static CYTHON_INLINE int __pyx_f_5numpy_import_array(void) {
   int __pyx_clineno = 0;
   __Pyx_RefNannySetupContext("import_array", 1);
 
-  /* "../../../../../tmp/pip-build-env-x4mieqja/overlay/lib/python3.12/site-packages/numpy/__init__.cython-30.pxd":981
+  /* "../../../../../tmp/pip-build-env-1f1oalyc/overlay/lib/python3.8/site-packages/numpy/__init__.cython-30.pxd":983
  * # Cython code.
  * cdef inline int import_array() except -1:
  *     try:             # <<<<<<<<<<<<<<
@@ -4107,16 +4117,16 @@ static CYTHON_INLINE int __pyx_f_5numpy_import_array(void) {
     __Pyx_XGOTREF(__pyx_t_3);
     /*try:*/ {
 
-      /* "../../../../../tmp/pip-build-env-x4mieqja/overlay/lib/python3.12/site-packages/numpy/__init__.cython-30.pxd":982
+      /* "../../../../../tmp/pip-build-env-1f1oalyc/overlay/lib/python3.8/site-packages/numpy/__init__.cython-30.pxd":984
  * cdef inline int import_array() except -1:
  *     try:
  *         __pyx_import_array()             # <<<<<<<<<<<<<<
  *     except Exception:
  *         raise ImportError("numpy.core.multiarray failed to import")
  */
-      __pyx_t_4 = _import_array(); if (unlikely(__pyx_t_4 == ((int)-1))) __PYX_ERR(1, 982, __pyx_L3_error)
+      __pyx_t_4 = _import_array(); if (unlikely(__pyx_t_4 == ((int)-1))) __PYX_ERR(1, 984, __pyx_L3_error)
 
-      /* "../../../../../tmp/pip-build-env-x4mieqja/overlay/lib/python3.12/site-packages/numpy/__init__.cython-30.pxd":981
+      /* "../../../../../tmp/pip-build-env-1f1oalyc/overlay/lib/python3.8/site-packages/numpy/__init__.cython-30.pxd":983
  * # Cython code.
  * cdef inline int import_array() except -1:
  *     try:             # <<<<<<<<<<<<<<
@@ -4130,7 +4140,7 @@ static CYTHON_INLINE int __pyx_f_5numpy_import_array(void) {
     goto __pyx_L8_try_end;
     __pyx_L3_error:;
 
-    /* "../../../../../tmp/pip-build-env-x4mieqja/overlay/lib/python3.12/site-packages/numpy/__init__.cython-30.pxd":983
+    /* "../../../../../tmp/pip-build-env-1f1oalyc/overlay/lib/python3.8/site-packages/numpy/__init__.cython-30.pxd":985
  *     try:
  *         __pyx_import_array()
  *     except Exception:             # <<<<<<<<<<<<<<
@@ -4140,27 +4150,27 @@ static CYTHON_INLINE int __pyx_f_5numpy_import_array(void) {
     __pyx_t_4 = __Pyx_PyErr_ExceptionMatches(((PyObject *)(&((PyTypeObject*)PyExc_Exception)[0])));
     if (__pyx_t_4) {
       __Pyx_AddTraceback("numpy.import_array", __pyx_clineno, __pyx_lineno, __pyx_filename);
-      if (__Pyx_GetException(&__pyx_t_5, &__pyx_t_6, &__pyx_t_7) < 0) __PYX_ERR(1, 983, __pyx_L5_except_error)
+      if (__Pyx_GetException(&__pyx_t_5, &__pyx_t_6, &__pyx_t_7) < 0) __PYX_ERR(1, 985, __pyx_L5_except_error)
       __Pyx_XGOTREF(__pyx_t_5);
       __Pyx_XGOTREF(__pyx_t_6);
       __Pyx_XGOTREF(__pyx_t_7);
 
-      /* "../../../../../tmp/pip-build-env-x4mieqja/overlay/lib/python3.12/site-packages/numpy/__init__.cython-30.pxd":984
+      /* "../../../../../tmp/pip-build-env-1f1oalyc/overlay/lib/python3.8/site-packages/numpy/__init__.cython-30.pxd":986
  *         __pyx_import_array()
  *     except Exception:
  *         raise ImportError("numpy.core.multiarray failed to import")             # <<<<<<<<<<<<<<
  * 
  * cdef inline int import_umath() except -1:
  */
-      __pyx_t_8 = __Pyx_PyObject_Call(__pyx_builtin_ImportError, __pyx_tuple_, NULL); if (unlikely(!__pyx_t_8)) __PYX_ERR(1, 984, __pyx_L5_except_error)
+      __pyx_t_8 = __Pyx_PyObject_Call(__pyx_builtin_ImportError, __pyx_tuple_, NULL); if (unlikely(!__pyx_t_8)) __PYX_ERR(1, 986, __pyx_L5_except_error)
       __Pyx_GOTREF(__pyx_t_8);
       __Pyx_Raise(__pyx_t_8, 0, 0, 0);
       __Pyx_DECREF(__pyx_t_8); __pyx_t_8 = 0;
-      __PYX_ERR(1, 984, __pyx_L5_except_error)
+      __PYX_ERR(1, 986, __pyx_L5_except_error)
     }
     goto __pyx_L5_except_error;
 
-    /* "../../../../../tmp/pip-build-env-x4mieqja/overlay/lib/python3.12/site-packages/numpy/__init__.cython-30.pxd":981
+    /* "../../../../../tmp/pip-build-env-1f1oalyc/overlay/lib/python3.8/site-packages/numpy/__init__.cython-30.pxd":983
  * # Cython code.
  * cdef inline int import_array() except -1:
  *     try:             # <<<<<<<<<<<<<<
@@ -4176,7 +4186,7 @@ static CYTHON_INLINE int __pyx_f_5numpy_import_array(void) {
     __pyx_L8_try_end:;
   }
 
-  /* "../../../../../tmp/pip-build-env-x4mieqja/overlay/lib/python3.12/site-packages/numpy/__init__.cython-30.pxd":980
+  /* "../../../../../tmp/pip-build-env-1f1oalyc/overlay/lib/python3.8/site-packages/numpy/__init__.cython-30.pxd":982
  * # Versions of the import_* functions which are more suitable for
  * # Cython code.
  * cdef inline int import_array() except -1:             # <<<<<<<<<<<<<<
@@ -4199,7 +4209,7 @@ static CYTHON_INLINE int __pyx_f_5numpy_import_array(void) {
   return __pyx_r;
 }
 
-/* "../../../../../tmp/pip-build-env-x4mieqja/overlay/lib/python3.12/site-packages/numpy/__init__.cython-30.pxd":986
+/* "../../../../../tmp/pip-build-env-1f1oalyc/overlay/lib/python3.8/site-packages/numpy/__init__.cython-30.pxd":988
  *         raise ImportError("numpy.core.multiarray failed to import")
  * 
  * cdef inline int import_umath() except -1:             # <<<<<<<<<<<<<<
@@ -4223,7 +4233,7 @@ static CYTHON_INLINE int __pyx_f_5numpy_import_umath(void) {
   int __pyx_clineno = 0;
   __Pyx_RefNannySetupContext("import_umath", 1);
 
-  /* "../../../../../tmp/pip-build-env-x4mieqja/overlay/lib/python3.12/site-packages/numpy/__init__.cython-30.pxd":987
+  /* "../../../../../tmp/pip-build-env-1f1oalyc/overlay/lib/python3.8/site-packages/numpy/__init__.cython-30.pxd":989
  * 
  * cdef inline int import_umath() except -1:
  *     try:             # <<<<<<<<<<<<<<
@@ -4239,16 +4249,16 @@ static CYTHON_INLINE int __pyx_f_5numpy_import_umath(void) {
     __Pyx_XGOTREF(__pyx_t_3);
     /*try:*/ {
 
-      /* "../../../../../tmp/pip-build-env-x4mieqja/overlay/lib/python3.12/site-packages/numpy/__init__.cython-30.pxd":988
+      /* "../../../../../tmp/pip-build-env-1f1oalyc/overlay/lib/python3.8/site-packages/numpy/__init__.cython-30.pxd":990
  * cdef inline int import_umath() except -1:
  *     try:
  *         _import_umath()             # <<<<<<<<<<<<<<
  *     except Exception:
  *         raise ImportError("numpy.core.umath failed to import")
  */
-      __pyx_t_4 = _import_umath(); if (unlikely(__pyx_t_4 == ((int)-1))) __PYX_ERR(1, 988, __pyx_L3_error)
+      __pyx_t_4 = _import_umath(); if (unlikely(__pyx_t_4 == ((int)-1))) __PYX_ERR(1, 990, __pyx_L3_error)
 
-      /* "../../../../../tmp/pip-build-env-x4mieqja/overlay/lib/python3.12/site-packages/numpy/__init__.cython-30.pxd":987
+      /* "../../../../../tmp/pip-build-env-1f1oalyc/overlay/lib/python3.8/site-packages/numpy/__init__.cython-30.pxd":989
  * 
  * cdef inline int import_umath() except -1:
  *     try:             # <<<<<<<<<<<<<<
@@ -4262,7 +4272,7 @@ static CYTHON_INLINE int __pyx_f_5numpy_import_umath(void) {
     goto __pyx_L8_try_end;
     __pyx_L3_error:;
 
-    /* "../../../../../tmp/pip-build-env-x4mieqja/overlay/lib/python3.12/site-packages/numpy/__init__.cython-30.pxd":989
+    /* "../../../../../tmp/pip-build-env-1f1oalyc/overlay/lib/python3.8/site-packages/numpy/__init__.cython-30.pxd":991
  *     try:
  *         _import_umath()
  *     except Exception:             # <<<<<<<<<<<<<<
@@ -4272,27 +4282,27 @@ static CYTHON_INLINE int __pyx_f_5numpy_import_umath(void) {
     __pyx_t_4 = __Pyx_PyErr_ExceptionMatches(((PyObject *)(&((PyTypeObject*)PyExc_Exception)[0])));
     if (__pyx_t_4) {
       __Pyx_AddTraceback("numpy.import_umath", __pyx_clineno, __pyx_lineno, __pyx_filename);
-      if (__Pyx_GetException(&__pyx_t_5, &__pyx_t_6, &__pyx_t_7) < 0) __PYX_ERR(1, 989, __pyx_L5_except_error)
+      if (__Pyx_GetException(&__pyx_t_5, &__pyx_t_6, &__pyx_t_7) < 0) __PYX_ERR(1, 991, __pyx_L5_except_error)
       __Pyx_XGOTREF(__pyx_t_5);
       __Pyx_XGOTREF(__pyx_t_6);
       __Pyx_XGOTREF(__pyx_t_7);
 
-      /* "../../../../../tmp/pip-build-env-x4mieqja/overlay/lib/python3.12/site-packages/numpy/__init__.cython-30.pxd":990
+      /* "../../../../../tmp/pip-build-env-1f1oalyc/overlay/lib/python3.8/site-packages/numpy/__init__.cython-30.pxd":992
  *         _import_umath()
  *     except Exception:
  *         raise ImportError("numpy.core.umath failed to import")             # <<<<<<<<<<<<<<
  * 
  * cdef inline int import_ufunc() except -1:
  */
-      __pyx_t_8 = __Pyx_PyObject_Call(__pyx_builtin_ImportError, __pyx_tuple__2, NULL); if (unlikely(!__pyx_t_8)) __PYX_ERR(1, 990, __pyx_L5_except_error)
+      __pyx_t_8 = __Pyx_PyObject_Call(__pyx_builtin_ImportError, __pyx_tuple__2, NULL); if (unlikely(!__pyx_t_8)) __PYX_ERR(1, 992, __pyx_L5_except_error)
       __Pyx_GOTREF(__pyx_t_8);
       __Pyx_Raise(__pyx_t_8, 0, 0, 0);
       __Pyx_DECREF(__pyx_t_8); __pyx_t_8 = 0;
-      __PYX_ERR(1, 990, __pyx_L5_except_error)
+      __PYX_ERR(1, 992, __pyx_L5_except_error)
     }
     goto __pyx_L5_except_error;
 
-    /* "../../../../../tmp/pip-build-env-x4mieqja/overlay/lib/python3.12/site-packages/numpy/__init__.cython-30.pxd":987
+    /* "../../../../../tmp/pip-build-env-1f1oalyc/overlay/lib/python3.8/site-packages/numpy/__init__.cython-30.pxd":989
  * 
  * cdef inline int import_umath() except -1:
  *     try:             # <<<<<<<<<<<<<<
@@ -4308,7 +4318,7 @@ static CYTHON_INLINE int __pyx_f_5numpy_import_umath(void) {
     __pyx_L8_try_end:;
   }
 
-  /* "../../../../../tmp/pip-build-env-x4mieqja/overlay/lib/python3.12/site-packages/numpy/__init__.cython-30.pxd":986
+  /* "../../../../../tmp/pip-build-env-1f1oalyc/overlay/lib/python3.8/site-packages/numpy/__init__.cython-30.pxd":988
  *         raise ImportError("numpy.core.multiarray failed to import")
  * 
  * cdef inline int import_umath() except -1:             # <<<<<<<<<<<<<<
@@ -4331,7 +4341,7 @@ static CYTHON_INLINE int __pyx_f_5numpy_import_umath(void) {
   return __pyx_r;
 }
 
-/* "../../../../../tmp/pip-build-env-x4mieqja/overlay/lib/python3.12/site-packages/numpy/__init__.cython-30.pxd":992
+/* "../../../../../tmp/pip-build-env-1f1oalyc/overlay/lib/python3.8/site-packages/numpy/__init__.cython-30.pxd":994
  *         raise ImportError("numpy.core.umath failed to import")
  * 
  * cdef inline int import_ufunc() except -1:             # <<<<<<<<<<<<<<
@@ -4355,7 +4365,7 @@ static CYTHON_INLINE int __pyx_f_5numpy_import_ufunc(void) {
   int __pyx_clineno = 0;
   __Pyx_RefNannySetupContext("import_ufunc", 1);
 
-  /* "../../../../../tmp/pip-build-env-x4mieqja/overlay/lib/python3.12/site-packages/numpy/__init__.cython-30.pxd":993
+  /* "../../../../../tmp/pip-build-env-1f1oalyc/overlay/lib/python3.8/site-packages/numpy/__init__.cython-30.pxd":995
  * 
  * cdef inline int import_ufunc() except -1:
  *     try:             # <<<<<<<<<<<<<<
@@ -4371,16 +4381,16 @@ static CYTHON_INLINE int __pyx_f_5numpy_import_ufunc(void) {
     __Pyx_XGOTREF(__pyx_t_3);
     /*try:*/ {
 
-      /* "../../../../../tmp/pip-build-env-x4mieqja/overlay/lib/python3.12/site-packages/numpy/__init__.cython-30.pxd":994
+      /* "../../../../../tmp/pip-build-env-1f1oalyc/overlay/lib/python3.8/site-packages/numpy/__init__.cython-30.pxd":996
  * cdef inline int import_ufunc() except -1:
  *     try:
  *         _import_umath()             # <<<<<<<<<<<<<<
  *     except Exception:
  *         raise ImportError("numpy.core.umath failed to import")
  */
-      __pyx_t_4 = _import_umath(); if (unlikely(__pyx_t_4 == ((int)-1))) __PYX_ERR(1, 994, __pyx_L3_error)
+      __pyx_t_4 = _import_umath(); if (unlikely(__pyx_t_4 == ((int)-1))) __PYX_ERR(1, 996, __pyx_L3_error)
 
-      /* "../../../../../tmp/pip-build-env-x4mieqja/overlay/lib/python3.12/site-packages/numpy/__init__.cython-30.pxd":993
+      /* "../../../../../tmp/pip-build-env-1f1oalyc/overlay/lib/python3.8/site-packages/numpy/__init__.cython-30.pxd":995
  * 
  * cdef inline int import_ufunc() except -1:
  *     try:             # <<<<<<<<<<<<<<
@@ -4394,7 +4404,7 @@ static CYTHON_INLINE int __pyx_f_5numpy_import_ufunc(void) {
     goto __pyx_L8_try_end;
     __pyx_L3_error:;
 
-    /* "../../../../../tmp/pip-build-env-x4mieqja/overlay/lib/python3.12/site-packages/numpy/__init__.cython-30.pxd":995
+    /* "../../../../../tmp/pip-build-env-1f1oalyc/overlay/lib/python3.8/site-packages/numpy/__init__.cython-30.pxd":997
  *     try:
  *         _import_umath()
  *     except Exception:             # <<<<<<<<<<<<<<
@@ -4404,27 +4414,27 @@ static CYTHON_INLINE int __pyx_f_5numpy_import_ufunc(void) {
     __pyx_t_4 = __Pyx_PyErr_ExceptionMatches(((PyObject *)(&((PyTypeObject*)PyExc_Exception)[0])));
     if (__pyx_t_4) {
       __Pyx_AddTraceback("numpy.import_ufunc", __pyx_clineno, __pyx_lineno, __pyx_filename);
-      if (__Pyx_GetException(&__pyx_t_5, &__pyx_t_6, &__pyx_t_7) < 0) __PYX_ERR(1, 995, __pyx_L5_except_error)
+      if (__Pyx_GetException(&__pyx_t_5, &__pyx_t_6, &__pyx_t_7) < 0) __PYX_ERR(1, 997, __pyx_L5_except_error)
       __Pyx_XGOTREF(__pyx_t_5);
       __Pyx_XGOTREF(__pyx_t_6);
       __Pyx_XGOTREF(__pyx_t_7);
 
-      /* "../../../../../tmp/pip-build-env-x4mieqja/overlay/lib/python3.12/site-packages/numpy/__init__.cython-30.pxd":996
+      /* "../../../../../tmp/pip-build-env-1f1oalyc/overlay/lib/python3.8/site-packages/numpy/__init__.cython-30.pxd":998
  *         _import_umath()
  *     except Exception:
  *         raise ImportError("numpy.core.umath failed to import")             # <<<<<<<<<<<<<<
  * 
  * 
  */
-      __pyx_t_8 = __Pyx_PyObject_Call(__pyx_builtin_ImportError, __pyx_tuple__2, NULL); if (unlikely(!__pyx_t_8)) __PYX_ERR(1, 996, __pyx_L5_except_error)
+      __pyx_t_8 = __Pyx_PyObject_Call(__pyx_builtin_ImportError, __pyx_tuple__2, NULL); if (unlikely(!__pyx_t_8)) __PYX_ERR(1, 998, __pyx_L5_except_error)
       __Pyx_GOTREF(__pyx_t_8);
       __Pyx_Raise(__pyx_t_8, 0, 0, 0);
       __Pyx_DECREF(__pyx_t_8); __pyx_t_8 = 0;
-      __PYX_ERR(1, 996, __pyx_L5_except_error)
+      __PYX_ERR(1, 998, __pyx_L5_except_error)
     }
     goto __pyx_L5_except_error;
 
-    /* "../../../../../tmp/pip-build-env-x4mieqja/overlay/lib/python3.12/site-packages/numpy/__init__.cython-30.pxd":993
+    /* "../../../../../tmp/pip-build-env-1f1oalyc/overlay/lib/python3.8/site-packages/numpy/__init__.cython-30.pxd":995
  * 
  * cdef inline int import_ufunc() except -1:
  *     try:             # <<<<<<<<<<<<<<
@@ -4440,7 +4450,7 @@ static CYTHON_INLINE int __pyx_f_5numpy_import_ufunc(void) {
     __pyx_L8_try_end:;
   }
 
-  /* "../../../../../tmp/pip-build-env-x4mieqja/overlay/lib/python3.12/site-packages/numpy/__init__.cython-30.pxd":992
+  /* "../../../../../tmp/pip-build-env-1f1oalyc/overlay/lib/python3.8/site-packages/numpy/__init__.cython-30.pxd":994
  *         raise ImportError("numpy.core.umath failed to import")
  * 
  * cdef inline int import_ufunc() except -1:             # <<<<<<<<<<<<<<
@@ -4463,7 +4473,7 @@ static CYTHON_INLINE int __pyx_f_5numpy_import_ufunc(void) {
   return __pyx_r;
 }
 
-/* "../../../../../tmp/pip-build-env-x4mieqja/overlay/lib/python3.12/site-packages/numpy/__init__.cython-30.pxd":999
+/* "../../../../../tmp/pip-build-env-1f1oalyc/overlay/lib/python3.8/site-packages/numpy/__init__.cython-30.pxd":1001
  * 
  * 
  * cdef inline bint is_timedelta64_object(object obj):             # <<<<<<<<<<<<<<
@@ -4474,7 +4484,7 @@ static CYTHON_INLINE int __pyx_f_5numpy_import_ufunc(void) {
 static CYTHON_INLINE int __pyx_f_5numpy_is_timedelta64_object(PyObject *__pyx_v_obj) {
   int __pyx_r;
 
-  /* "../../../../../tmp/pip-build-env-x4mieqja/overlay/lib/python3.12/site-packages/numpy/__init__.cython-30.pxd":1011
+  /* "../../../../../tmp/pip-build-env-1f1oalyc/overlay/lib/python3.8/site-packages/numpy/__init__.cython-30.pxd":1013
  *     bool
  *     """
  *     return PyObject_TypeCheck(obj, &PyTimedeltaArrType_Type)             # <<<<<<<<<<<<<<
@@ -4484,7 +4494,7 @@ static CYTHON_INLINE int __pyx_f_5numpy_is_timedelta64_object(PyObject *__pyx_v_
   __pyx_r = PyObject_TypeCheck(__pyx_v_obj, (&PyTimedeltaArrType_Type));
   goto __pyx_L0;
 
-  /* "../../../../../tmp/pip-build-env-x4mieqja/overlay/lib/python3.12/site-packages/numpy/__init__.cython-30.pxd":999
+  /* "../../../../../tmp/pip-build-env-1f1oalyc/overlay/lib/python3.8/site-packages/numpy/__init__.cython-30.pxd":1001
  * 
  * 
  * cdef inline bint is_timedelta64_object(object obj):             # <<<<<<<<<<<<<<
@@ -4497,7 +4507,7 @@ static CYTHON_INLINE int __pyx_f_5numpy_is_timedelta64_object(PyObject *__pyx_v_
   return __pyx_r;
 }
 
-/* "../../../../../tmp/pip-build-env-x4mieqja/overlay/lib/python3.12/site-packages/numpy/__init__.cython-30.pxd":1014
+/* "../../../../../tmp/pip-build-env-1f1oalyc/overlay/lib/python3.8/site-packages/numpy/__init__.cython-30.pxd":1016
  * 
  * 
  * cdef inline bint is_datetime64_object(object obj):             # <<<<<<<<<<<<<<
@@ -4508,7 +4518,7 @@ static CYTHON_INLINE int __pyx_f_5numpy_is_timedelta64_object(PyObject *__pyx_v_
 static CYTHON_INLINE int __pyx_f_5numpy_is_datetime64_object(PyObject *__pyx_v_obj) {
   int __pyx_r;
 
-  /* "../../../../../tmp/pip-build-env-x4mieqja/overlay/lib/python3.12/site-packages/numpy/__init__.cython-30.pxd":1026
+  /* "../../../../../tmp/pip-build-env-1f1oalyc/overlay/lib/python3.8/site-packages/numpy/__init__.cython-30.pxd":1028
  *     bool
  *     """
  *     return PyObject_TypeCheck(obj, &PyDatetimeArrType_Type)             # <<<<<<<<<<<<<<
@@ -4518,7 +4528,7 @@ static CYTHON_INLINE int __pyx_f_5numpy_is_datetime64_object(PyObject *__pyx_v_o
   __pyx_r = PyObject_TypeCheck(__pyx_v_obj, (&PyDatetimeArrType_Type));
   goto __pyx_L0;
 
-  /* "../../../../../tmp/pip-build-env-x4mieqja/overlay/lib/python3.12/site-packages/numpy/__init__.cython-30.pxd":1014
+  /* "../../../../../tmp/pip-build-env-1f1oalyc/overlay/lib/python3.8/site-packages/numpy/__init__.cython-30.pxd":1016
  * 
  * 
  * cdef inline bint is_datetime64_object(object obj):             # <<<<<<<<<<<<<<
@@ -4531,7 +4541,7 @@ static CYTHON_INLINE int __pyx_f_5numpy_is_datetime64_object(PyObject *__pyx_v_o
   return __pyx_r;
 }
 
-/* "../../../../../tmp/pip-build-env-x4mieqja/overlay/lib/python3.12/site-packages/numpy/__init__.cython-30.pxd":1029
+/* "../../../../../tmp/pip-build-env-1f1oalyc/overlay/lib/python3.8/site-packages/numpy/__init__.cython-30.pxd":1031
  * 
  * 
  * cdef inline npy_datetime get_datetime64_value(object obj) nogil:             # <<<<<<<<<<<<<<
@@ -4542,7 +4552,7 @@ static CYTHON_INLINE int __pyx_f_5numpy_is_datetime64_object(PyObject *__pyx_v_o
 static CYTHON_INLINE npy_datetime __pyx_f_5numpy_get_datetime64_value(PyObject *__pyx_v_obj) {
   npy_datetime __pyx_r;
 
-  /* "../../../../../tmp/pip-build-env-x4mieqja/overlay/lib/python3.12/site-packages/numpy/__init__.cython-30.pxd":1036
+  /* "../../../../../tmp/pip-build-env-1f1oalyc/overlay/lib/python3.8/site-packages/numpy/__init__.cython-30.pxd":1038
  *     also needed.  That can be found using `get_datetime64_unit`.
  *     """
  *     return (<PyDatetimeScalarObject*>obj).obval             # <<<<<<<<<<<<<<
@@ -4552,7 +4562,7 @@ static CYTHON_INLINE npy_datetime __pyx_f_5numpy_get_datetime64_value(PyObject *
   __pyx_r = ((PyDatetimeScalarObject *)__pyx_v_obj)->obval;
   goto __pyx_L0;
 
-  /* "../../../../../tmp/pip-build-env-x4mieqja/overlay/lib/python3.12/site-packages/numpy/__init__.cython-30.pxd":1029
+  /* "../../../../../tmp/pip-build-env-1f1oalyc/overlay/lib/python3.8/site-packages/numpy/__init__.cython-30.pxd":1031
  * 
  * 
  * cdef inline npy_datetime get_datetime64_value(object obj) nogil:             # <<<<<<<<<<<<<<
@@ -4565,7 +4575,7 @@ static CYTHON_INLINE npy_datetime __pyx_f_5numpy_get_datetime64_value(PyObject *
   return __pyx_r;
 }
 
-/* "../../../../../tmp/pip-build-env-x4mieqja/overlay/lib/python3.12/site-packages/numpy/__init__.cython-30.pxd":1039
+/* "../../../../../tmp/pip-build-env-1f1oalyc/overlay/lib/python3.8/site-packages/numpy/__init__.cython-30.pxd":1041
  * 
  * 
  * cdef inline npy_timedelta get_timedelta64_value(object obj) nogil:             # <<<<<<<<<<<<<<
@@ -4576,7 +4586,7 @@ static CYTHON_INLINE npy_datetime __pyx_f_5numpy_get_datetime64_value(PyObject *
 static CYTHON_INLINE npy_timedelta __pyx_f_5numpy_get_timedelta64_value(PyObject *__pyx_v_obj) {
   npy_timedelta __pyx_r;
 
-  /* "../../../../../tmp/pip-build-env-x4mieqja/overlay/lib/python3.12/site-packages/numpy/__init__.cython-30.pxd":1043
+  /* "../../../../../tmp/pip-build-env-1f1oalyc/overlay/lib/python3.8/site-packages/numpy/__init__.cython-30.pxd":1045
  *     returns the int64 value underlying scalar numpy timedelta64 object
  *     """
  *     return (<PyTimedeltaScalarObject*>obj).obval             # <<<<<<<<<<<<<<
@@ -4586,7 +4596,7 @@ static CYTHON_INLINE npy_timedelta __pyx_f_5numpy_get_timedelta64_value(PyObject
   __pyx_r = ((PyTimedeltaScalarObject *)__pyx_v_obj)->obval;
   goto __pyx_L0;
 
-  /* "../../../../../tmp/pip-build-env-x4mieqja/overlay/lib/python3.12/site-packages/numpy/__init__.cython-30.pxd":1039
+  /* "../../../../../tmp/pip-build-env-1f1oalyc/overlay/lib/python3.8/site-packages/numpy/__init__.cython-30.pxd":1041
  * 
  * 
  * cdef inline npy_timedelta get_timedelta64_value(object obj) nogil:             # <<<<<<<<<<<<<<
@@ -4599,7 +4609,7 @@ static CYTHON_INLINE npy_timedelta __pyx_f_5numpy_get_timedelta64_value(PyObject
   return __pyx_r;
 }
 
-/* "../../../../../tmp/pip-build-env-x4mieqja/overlay/lib/python3.12/site-packages/numpy/__init__.cython-30.pxd":1046
+/* "../../../../../tmp/pip-build-env-1f1oalyc/overlay/lib/python3.8/site-packages/numpy/__init__.cython-30.pxd":1048
  * 
  * 
  * cdef inline NPY_DATETIMEUNIT get_datetime64_unit(object obj) nogil:             # <<<<<<<<<<<<<<
@@ -4610,7 +4620,7 @@ static CYTHON_INLINE npy_timedelta __pyx_f_5numpy_get_timedelta64_value(PyObject
 static CYTHON_INLINE NPY_DATETIMEUNIT __pyx_f_5numpy_get_datetime64_unit(PyObject *__pyx_v_obj) {
   NPY_DATETIMEUNIT __pyx_r;
 
-  /* "../../../../../tmp/pip-build-env-x4mieqja/overlay/lib/python3.12/site-packages/numpy/__init__.cython-30.pxd":1050
+  /* "../../../../../tmp/pip-build-env-1f1oalyc/overlay/lib/python3.8/site-packages/numpy/__init__.cython-30.pxd":1052
  *     returns the unit part of the dtype for a numpy datetime64 object.
  *     """
  *     return <NPY_DATETIMEUNIT>(<PyDatetimeScalarObject*>obj).obmeta.base             # <<<<<<<<<<<<<<
@@ -4618,7 +4628,7 @@ static CYTHON_INLINE NPY_DATETIMEUNIT __pyx_f_5numpy_get_datetime64_unit(PyObjec
   __pyx_r = ((NPY_DATETIMEUNIT)((PyDatetimeScalarObject *)__pyx_v_obj)->obmeta.base);
   goto __pyx_L0;
 
-  /* "../../../../../tmp/pip-build-env-x4mieqja/overlay/lib/python3.12/site-packages/numpy/__init__.cython-30.pxd":1046
+  /* "../../../../../tmp/pip-build-env-1f1oalyc/overlay/lib/python3.8/site-packages/numpy/__init__.cython-30.pxd":1048
  * 
  * 
  * cdef inline NPY_DATETIMEUNIT get_datetime64_unit(object obj) nogil:             # <<<<<<<<<<<<<<
@@ -6012,7 +6022,7 @@ static int __Pyx_CreateStringTabAndInitStrings(void) {
 static CYTHON_SMALL_CODE int __Pyx_InitCachedBuiltins(void) {
   __pyx_builtin_RuntimeError = __Pyx_GetBuiltinName(__pyx_n_s_RuntimeError); if (!__pyx_builtin_RuntimeError) __PYX_ERR(0, 94, __pyx_L1_error)
   __pyx_builtin_KeyError = __Pyx_GetBuiltinName(__pyx_n_s_KeyError); if (!__pyx_builtin_KeyError) __PYX_ERR(0, 149, __pyx_L1_error)
-  __pyx_builtin_ImportError = __Pyx_GetBuiltinName(__pyx_n_s_ImportError); if (!__pyx_builtin_ImportError) __PYX_ERR(1, 984, __pyx_L1_error)
+  __pyx_builtin_ImportError = __Pyx_GetBuiltinName(__pyx_n_s_ImportError); if (!__pyx_builtin_ImportError) __PYX_ERR(1, 986, __pyx_L1_error)
   return 0;
   __pyx_L1_error:;
   return -1;
@@ -6023,25 +6033,25 @@ static CYTHON_SMALL_CODE int __Pyx_InitCachedConstants(void) {
   __Pyx_RefNannyDeclarations
   __Pyx_RefNannySetupContext("__Pyx_InitCachedConstants", 0);
 
-  /* "../../../../../tmp/pip-build-env-x4mieqja/overlay/lib/python3.12/site-packages/numpy/__init__.cython-30.pxd":984
+  /* "../../../../../tmp/pip-build-env-1f1oalyc/overlay/lib/python3.8/site-packages/numpy/__init__.cython-30.pxd":986
  *         __pyx_import_array()
  *     except Exception:
  *         raise ImportError("numpy.core.multiarray failed to import")             # <<<<<<<<<<<<<<
  * 
  * cdef inline int import_umath() except -1:
  */
-  __pyx_tuple_ = PyTuple_Pack(1, __pyx_kp_u_numpy_core_multiarray_failed_to); if (unlikely(!__pyx_tuple_)) __PYX_ERR(1, 984, __pyx_L1_error)
+  __pyx_tuple_ = PyTuple_Pack(1, __pyx_kp_u_numpy_core_multiarray_failed_to); if (unlikely(!__pyx_tuple_)) __PYX_ERR(1, 986, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_tuple_);
   __Pyx_GIVEREF(__pyx_tuple_);
 
-  /* "../../../../../tmp/pip-build-env-x4mieqja/overlay/lib/python3.12/site-packages/numpy/__init__.cython-30.pxd":990
+  /* "../../../../../tmp/pip-build-env-1f1oalyc/overlay/lib/python3.8/site-packages/numpy/__init__.cython-30.pxd":992
  *         _import_umath()
  *     except Exception:
  *         raise ImportError("numpy.core.umath failed to import")             # <<<<<<<<<<<<<<
  * 
  * cdef inline int import_ufunc() except -1:
  */
-  __pyx_tuple__2 = PyTuple_Pack(1, __pyx_kp_u_numpy_core_umath_failed_to_impor); if (unlikely(!__pyx_tuple__2)) __PYX_ERR(1, 990, __pyx_L1_error)
+  __pyx_tuple__2 = PyTuple_Pack(1, __pyx_kp_u_numpy_core_umath_failed_to_impor); if (unlikely(!__pyx_tuple__2)) __PYX_ERR(1, 992, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_tuple__2);
   __Pyx_GIVEREF(__pyx_tuple__2);
 
@@ -6198,17 +6208,17 @@ static int __Pyx_modinit_type_import_code(void) {
   __pyx_ptype_5numpy_flatiter = __Pyx_ImportType_3_0_7(__pyx_t_1, "numpy", "flatiter", sizeof(PyArrayIterObject), __PYX_GET_STRUCT_ALIGNMENT_3_0_7(PyArrayIterObject),__Pyx_ImportType_CheckSize_Ignore_3_0_7); if (!__pyx_ptype_5numpy_flatiter) __PYX_ERR(1, 225, __pyx_L1_error)
   __pyx_ptype_5numpy_broadcast = __Pyx_ImportType_3_0_7(__pyx_t_1, "numpy", "broadcast", sizeof(PyArrayMultiIterObject), __PYX_GET_STRUCT_ALIGNMENT_3_0_7(PyArrayMultiIterObject),__Pyx_ImportType_CheckSize_Ignore_3_0_7); if (!__pyx_ptype_5numpy_broadcast) __PYX_ERR(1, 229, __pyx_L1_error)
   __pyx_ptype_5numpy_ndarray = __Pyx_ImportType_3_0_7(__pyx_t_1, "numpy", "ndarray", sizeof(PyArrayObject), __PYX_GET_STRUCT_ALIGNMENT_3_0_7(PyArrayObject),__Pyx_ImportType_CheckSize_Ignore_3_0_7); if (!__pyx_ptype_5numpy_ndarray) __PYX_ERR(1, 238, __pyx_L1_error)
-  __pyx_ptype_5numpy_generic = __Pyx_ImportType_3_0_7(__pyx_t_1, "numpy", "generic", sizeof(PyObject), __PYX_GET_STRUCT_ALIGNMENT_3_0_7(PyObject),__Pyx_ImportType_CheckSize_Warn_3_0_7); if (!__pyx_ptype_5numpy_generic) __PYX_ERR(1, 809, __pyx_L1_error)
-  __pyx_ptype_5numpy_number = __Pyx_ImportType_3_0_7(__pyx_t_1, "numpy", "number", sizeof(PyObject), __PYX_GET_STRUCT_ALIGNMENT_3_0_7(PyObject),__Pyx_ImportType_CheckSize_Warn_3_0_7); if (!__pyx_ptype_5numpy_number) __PYX_ERR(1, 811, __pyx_L1_error)
-  __pyx_ptype_5numpy_integer = __Pyx_ImportType_3_0_7(__pyx_t_1, "numpy", "integer", sizeof(PyObject), __PYX_GET_STRUCT_ALIGNMENT_3_0_7(PyObject),__Pyx_ImportType_CheckSize_Warn_3_0_7); if (!__pyx_ptype_5numpy_integer) __PYX_ERR(1, 813, __pyx_L1_error)
-  __pyx_ptype_5numpy_signedinteger = __Pyx_ImportType_3_0_7(__pyx_t_1, "numpy", "signedinteger", sizeof(PyObject), __PYX_GET_STRUCT_ALIGNMENT_3_0_7(PyObject),__Pyx_ImportType_CheckSize_Warn_3_0_7); if (!__pyx_ptype_5numpy_signedinteger) __PYX_ERR(1, 815, __pyx_L1_error)
-  __pyx_ptype_5numpy_unsignedinteger = __Pyx_ImportType_3_0_7(__pyx_t_1, "numpy", "unsignedinteger", sizeof(PyObject), __PYX_GET_STRUCT_ALIGNMENT_3_0_7(PyObject),__Pyx_ImportType_CheckSize_Warn_3_0_7); if (!__pyx_ptype_5numpy_unsignedinteger) __PYX_ERR(1, 817, __pyx_L1_error)
-  __pyx_ptype_5numpy_inexact = __Pyx_ImportType_3_0_7(__pyx_t_1, "numpy", "inexact", sizeof(PyObject), __PYX_GET_STRUCT_ALIGNMENT_3_0_7(PyObject),__Pyx_ImportType_CheckSize_Warn_3_0_7); if (!__pyx_ptype_5numpy_inexact) __PYX_ERR(1, 819, __pyx_L1_error)
-  __pyx_ptype_5numpy_floating = __Pyx_ImportType_3_0_7(__pyx_t_1, "numpy", "floating", sizeof(PyObject), __PYX_GET_STRUCT_ALIGNMENT_3_0_7(PyObject),__Pyx_ImportType_CheckSize_Warn_3_0_7); if (!__pyx_ptype_5numpy_floating) __PYX_ERR(1, 821, __pyx_L1_error)
-  __pyx_ptype_5numpy_complexfloating = __Pyx_ImportType_3_0_7(__pyx_t_1, "numpy", "complexfloating", sizeof(PyObject), __PYX_GET_STRUCT_ALIGNMENT_3_0_7(PyObject),__Pyx_ImportType_CheckSize_Warn_3_0_7); if (!__pyx_ptype_5numpy_complexfloating) __PYX_ERR(1, 823, __pyx_L1_error)
-  __pyx_ptype_5numpy_flexible = __Pyx_ImportType_3_0_7(__pyx_t_1, "numpy", "flexible", sizeof(PyObject), __PYX_GET_STRUCT_ALIGNMENT_3_0_7(PyObject),__Pyx_ImportType_CheckSize_Warn_3_0_7); if (!__pyx_ptype_5numpy_flexible) __PYX_ERR(1, 825, __pyx_L1_error)
-  __pyx_ptype_5numpy_character = __Pyx_ImportType_3_0_7(__pyx_t_1, "numpy", "character", sizeof(PyObject), __PYX_GET_STRUCT_ALIGNMENT_3_0_7(PyObject),__Pyx_ImportType_CheckSize_Warn_3_0_7); if (!__pyx_ptype_5numpy_character) __PYX_ERR(1, 827, __pyx_L1_error)
-  __pyx_ptype_5numpy_ufunc = __Pyx_ImportType_3_0_7(__pyx_t_1, "numpy", "ufunc", sizeof(PyUFuncObject), __PYX_GET_STRUCT_ALIGNMENT_3_0_7(PyUFuncObject),__Pyx_ImportType_CheckSize_Ignore_3_0_7); if (!__pyx_ptype_5numpy_ufunc) __PYX_ERR(1, 866, __pyx_L1_error)
+  __pyx_ptype_5numpy_generic = __Pyx_ImportType_3_0_7(__pyx_t_1, "numpy", "generic", sizeof(PyObject), __PYX_GET_STRUCT_ALIGNMENT_3_0_7(PyObject),__Pyx_ImportType_CheckSize_Warn_3_0_7); if (!__pyx_ptype_5numpy_generic) __PYX_ERR(1, 812, __pyx_L1_error)
+  __pyx_ptype_5numpy_number = __Pyx_ImportType_3_0_7(__pyx_t_1, "numpy", "number", sizeof(PyObject), __PYX_GET_STRUCT_ALIGNMENT_3_0_7(PyObject),__Pyx_ImportType_CheckSize_Warn_3_0_7); if (!__pyx_ptype_5numpy_number) __PYX_ERR(1, 814, __pyx_L1_error)
+  __pyx_ptype_5numpy_integer = __Pyx_ImportType_3_0_7(__pyx_t_1, "numpy", "integer", sizeof(PyObject), __PYX_GET_STRUCT_ALIGNMENT_3_0_7(PyObject),__Pyx_ImportType_CheckSize_Warn_3_0_7); if (!__pyx_ptype_5numpy_integer) __PYX_ERR(1, 816, __pyx_L1_error)
+  __pyx_ptype_5numpy_signedinteger = __Pyx_ImportType_3_0_7(__pyx_t_1, "numpy", "signedinteger", sizeof(PyObject), __PYX_GET_STRUCT_ALIGNMENT_3_0_7(PyObject),__Pyx_ImportType_CheckSize_Warn_3_0_7); if (!__pyx_ptype_5numpy_signedinteger) __PYX_ERR(1, 818, __pyx_L1_error)
+  __pyx_ptype_5numpy_unsignedinteger = __Pyx_ImportType_3_0_7(__pyx_t_1, "numpy", "unsignedinteger", sizeof(PyObject), __PYX_GET_STRUCT_ALIGNMENT_3_0_7(PyObject),__Pyx_ImportType_CheckSize_Warn_3_0_7); if (!__pyx_ptype_5numpy_unsignedinteger) __PYX_ERR(1, 820, __pyx_L1_error)
+  __pyx_ptype_5numpy_inexact = __Pyx_ImportType_3_0_7(__pyx_t_1, "numpy", "inexact", sizeof(PyObject), __PYX_GET_STRUCT_ALIGNMENT_3_0_7(PyObject),__Pyx_ImportType_CheckSize_Warn_3_0_7); if (!__pyx_ptype_5numpy_inexact) __PYX_ERR(1, 822, __pyx_L1_error)
+  __pyx_ptype_5numpy_floating = __Pyx_ImportType_3_0_7(__pyx_t_1, "numpy", "floating", sizeof(PyObject), __PYX_GET_STRUCT_ALIGNMENT_3_0_7(PyObject),__Pyx_ImportType_CheckSize_Warn_3_0_7); if (!__pyx_ptype_5numpy_floating) __PYX_ERR(1, 824, __pyx_L1_error)
+  __pyx_ptype_5numpy_complexfloating = __Pyx_ImportType_3_0_7(__pyx_t_1, "numpy", "complexfloating", sizeof(PyObject), __PYX_GET_STRUCT_ALIGNMENT_3_0_7(PyObject),__Pyx_ImportType_CheckSize_Warn_3_0_7); if (!__pyx_ptype_5numpy_complexfloating) __PYX_ERR(1, 826, __pyx_L1_error)
+  __pyx_ptype_5numpy_flexible = __Pyx_ImportType_3_0_7(__pyx_t_1, "numpy", "flexible", sizeof(PyObject), __PYX_GET_STRUCT_ALIGNMENT_3_0_7(PyObject),__Pyx_ImportType_CheckSize_Warn_3_0_7); if (!__pyx_ptype_5numpy_flexible) __PYX_ERR(1, 828, __pyx_L1_error)
+  __pyx_ptype_5numpy_character = __Pyx_ImportType_3_0_7(__pyx_t_1, "numpy", "character", sizeof(PyObject), __PYX_GET_STRUCT_ALIGNMENT_3_0_7(PyObject),__Pyx_ImportType_CheckSize_Warn_3_0_7); if (!__pyx_ptype_5numpy_character) __PYX_ERR(1, 830, __pyx_L1_error)
+  __pyx_ptype_5numpy_ufunc = __Pyx_ImportType_3_0_7(__pyx_t_1, "numpy", "ufunc", sizeof(PyUFuncObject), __PYX_GET_STRUCT_ALIGNMENT_3_0_7(PyUFuncObject),__Pyx_ImportType_CheckSize_Ignore_3_0_7); if (!__pyx_ptype_5numpy_ufunc) __PYX_ERR(1, 868, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
   __Pyx_RefNannyFinishContext();
   return 0;

--- a/openjpeg/tests/__init__.py
+++ b/openjpeg/tests/__init__.py
@@ -3,8 +3,9 @@ import sys
 # Add the testing data to openjpeg (if available)
 try:
     import ljdata as _data
-    globals()['data'] = _data
+
+    globals()["data"] = _data
     # Add to cache - needed for pytest
-    sys.modules['openjpeg.data'] = _data
+    sys.modules["openjpeg.data"] = _data
 except ImportError:
     pass

--- a/openjpeg/tests/test_decode.py
+++ b/openjpeg/tests/test_decode.py
@@ -1,14 +1,14 @@
 """Unit tests for openjpeg."""
 
 from io import BytesIO
-import os
 
 try:
-    import pydicom
     from pydicom.encaps import generate_pixel_data_frame
     from pydicom.pixel_data_handlers.util import (
-        reshape_pixel_array, get_expected_length, pixel_dtype
+        reshape_pixel_array,
+        pixel_dtype,
     )
+
     HAS_PYDICOM = True
 except ImportError:
     HAS_PYDICOM = False
@@ -20,45 +20,44 @@ from openjpeg.data import get_indexed_datasets, JPEG_DIRECTORY
 from openjpeg.utils import (
     get_openjpeg_version,
     decode,
-    get_parameters,
     decode_pixel_data,
     _get_format,
 )
 
 
-DIR_15444 = JPEG_DIRECTORY / '15444'
+DIR_15444 = JPEG_DIRECTORY / "15444"
 
 
 REF_DCM = {
-    '1.2.840.10008.1.2.4.90' : [
+    "1.2.840.10008.1.2.4.90": [
         # filename, (rows, columns, samples/px, bits/sample, signed?)
-        ('693_J2KR.dcm', (512, 512, 1, 14, True)),
-        ('966_fixed.dcm', (2128, 2000, 1, 12, False)),
-        ('emri_small_jpeg_2k_lossless.dcm', (64, 64, 1, 16, False)),
-        ('explicit_VR-UN.dcm', (512, 512, 1, 16, True)),
-        ('GDCMJ2K_TextGBR.dcm', (400, 400, 3, 8, False)),
-        ('JPEG2KLossless_1s_1f_u_16_16.dcm', (1416, 1420, 1, 16, False)),
-        ('MR_small_jp2klossless.dcm', (64, 64, 1, 16, True)),
-        ('MR2_J2KR.dcm', (1024, 1024, 1, 12, False)),
-        ('NM_Kakadu44_SOTmarkerincons.dcm', (2500, 2048, 1, 16, False)),
-        ('RG1_J2KR.dcm', (1955, 1841, 1, 15, False)),
-        ('RG3_J2KR.dcm', (1760, 1760, 1, 10, False)),
-        ('TOSHIBA_J2K_OpenJPEGv2Regression.dcm', (512, 512, 1, 16, True)),
-        ('TOSHIBA_J2K_SIZ0_PixRep1.dcm', (512, 512, 1, 16, True)),
-        ('TOSHIBA_J2K_SIZ1_PixRep0.dcm', (512, 512, 1, 16, False)),
-        ('US1_J2KR.dcm', (480, 640, 3, 8, False)),
+        ("693_J2KR.dcm", (512, 512, 1, 14, True)),
+        ("966_fixed.dcm", (2128, 2000, 1, 12, False)),
+        ("emri_small_jpeg_2k_lossless.dcm", (64, 64, 1, 16, False)),
+        ("explicit_VR-UN.dcm", (512, 512, 1, 16, True)),
+        ("GDCMJ2K_TextGBR.dcm", (400, 400, 3, 8, False)),
+        ("JPEG2KLossless_1s_1f_u_16_16.dcm", (1416, 1420, 1, 16, False)),
+        ("MR_small_jp2klossless.dcm", (64, 64, 1, 16, True)),
+        ("MR2_J2KR.dcm", (1024, 1024, 1, 12, False)),
+        ("NM_Kakadu44_SOTmarkerincons.dcm", (2500, 2048, 1, 16, False)),
+        ("RG1_J2KR.dcm", (1955, 1841, 1, 15, False)),
+        ("RG3_J2KR.dcm", (1760, 1760, 1, 10, False)),
+        ("TOSHIBA_J2K_OpenJPEGv2Regression.dcm", (512, 512, 1, 16, True)),
+        ("TOSHIBA_J2K_SIZ0_PixRep1.dcm", (512, 512, 1, 16, True)),
+        ("TOSHIBA_J2K_SIZ1_PixRep0.dcm", (512, 512, 1, 16, False)),
+        ("US1_J2KR.dcm", (480, 640, 3, 8, False)),
     ],
-    '1.2.840.10008.1.2.4.91' : [
-        ('693_J2KI.dcm', (512, 512, 1, 16, True)),
-        ('ELSCINT1_JP2vsJ2K.dcm', (512, 512, 1, 12, False)),
-        ('JPEG2000.dcm', (1024, 256, 1, 16, True)),
-        ('MAROTECH_CT_JP2Lossy.dcm', (716, 512, 1, 12, False)),
-        ('MR2_J2KI.dcm', (1024, 1024, 1, 12, False)),
-        ('OsirixFake16BitsStoredFakeSpacing.dcm', (224, 176, 1, 16, False)),
-        ('RG1_J2KI.dcm', (1955, 1841, 1, 15, False)),
-        ('RG3_J2KI.dcm', (1760, 1760, 1, 10, False)),
-        ('SC_rgb_gdcm_KY.dcm', (100, 100, 3, 8, False)),
-        ('US1_J2KI.dcm', (480, 640, 3, 8, False)),
+    "1.2.840.10008.1.2.4.91": [
+        ("693_J2KI.dcm", (512, 512, 1, 16, True)),
+        ("ELSCINT1_JP2vsJ2K.dcm", (512, 512, 1, 12, False)),
+        ("JPEG2000.dcm", (1024, 256, 1, 16, True)),
+        ("MAROTECH_CT_JP2Lossy.dcm", (716, 512, 1, 12, False)),
+        ("MR2_J2KI.dcm", (1024, 1024, 1, 12, False)),
+        ("OsirixFake16BitsStoredFakeSpacing.dcm", (224, 176, 1, 16, False)),
+        ("RG1_J2KI.dcm", (1955, 1841, 1, 15, False)),
+        ("RG3_J2KI.dcm", (1760, 1760, 1, 10, False)),
+        ("SC_rgb_gdcm_KY.dcm", (100, 100, 3, 8, False)),
+        ("US1_J2KI.dcm", (480, 640, 3, 8, False)),
     ],
 }
 
@@ -75,7 +74,7 @@ def test_version():
 
 def generate_frames(ds):
     """Return a frame generator for DICOM datasets."""
-    nr_frames = ds.get('NumberOfFrames', 1)
+    nr_frames = ds.get("NumberOfFrames", 1)
     return generate_pixel_data_frame(ds.PixelData, nr_frames)
 
 
@@ -90,8 +89,8 @@ def test_get_format_raises():
 @pytest.mark.skipif(not HAS_PYDICOM, reason="No pydicom")
 def test_bad_decode():
     """Test trying to decode bad data."""
-    index = get_indexed_datasets('1.2.840.10008.1.2.4.90')
-    ds = index['966.dcm']['ds']
+    index = get_indexed_datasets("1.2.840.10008.1.2.4.90")
+    ds = index["966.dcm"]["ds"]
     frame = next(generate_frames(ds))
     msg = r"Error decoding the J2K data: failed to decode image"
     with pytest.raises(RuntimeError, match=msg):
@@ -100,16 +99,17 @@ def test_bad_decode():
 
 class TestDecode:
     """General tests for decode."""
+
     @pytest.mark.skipif(not HAS_PYDICOM, reason="No pydicom")
     def test_decode_bytes(self):
         """Test decoding using bytes."""
-        index = get_indexed_datasets('1.2.840.10008.1.2.4.90')
-        ds = index['MR_small_jp2klossless.dcm']['ds']
+        index = get_indexed_datasets("1.2.840.10008.1.2.4.90")
+        ds = index["MR_small_jp2klossless.dcm"]["ds"]
         frame = next(generate_frames(ds))
         assert isinstance(frame, bytes)
         arr = decode(frame)
         assert arr.flags.writeable
-        assert 'int16' == arr.dtype
+        assert "int16" == arr.dtype
         assert (ds.Rows, ds.Columns) == arr.shape
 
         # It'd be nice to standardise the pixel value testing...
@@ -121,13 +121,13 @@ class TestDecode:
     @pytest.mark.skipif(not HAS_PYDICOM, reason="No pydicom")
     def test_decode_filelike(self):
         """Test decoding using file-like."""
-        index = get_indexed_datasets('1.2.840.10008.1.2.4.90')
-        ds = index['MR_small_jp2klossless.dcm']['ds']
+        index = get_indexed_datasets("1.2.840.10008.1.2.4.90")
+        ds = index["MR_small_jp2klossless.dcm"]["ds"]
         frame = BytesIO(next(generate_frames(ds)))
         assert isinstance(frame, BytesIO)
         arr = decode(frame)
         assert arr.flags.writeable
-        assert 'int16' == arr.dtype
+        assert "int16" == arr.dtype
         assert (ds.Rows, ds.Columns) == arr.shape
 
         # It'd be nice to standardise the pixel value testing...
@@ -139,10 +139,10 @@ class TestDecode:
     @pytest.mark.skipif(not HAS_PYDICOM, reason="No pydicom")
     def test_decode_bad_type_raises(self):
         """Test decoding using invalid type raises."""
-        index = get_indexed_datasets('1.2.840.10008.1.2.4.90')
-        ds = index['MR_small_jp2klossless.dcm']['ds']
+        index = get_indexed_datasets("1.2.840.10008.1.2.4.90")
+        ds = index["MR_small_jp2klossless.dcm"]["ds"]
         frame = tuple(next(generate_frames(ds)))
-        assert not hasattr(frame, 'tell') and not isinstance(frame, bytes)
+        assert not hasattr(frame, "tell") and not isinstance(frame, bytes)
 
         msg = (
             r"The Python object containing the encoded JPEG 2000 data must "
@@ -154,8 +154,8 @@ class TestDecode:
     @pytest.mark.skipif(not HAS_PYDICOM, reason="No pydicom")
     def test_decode_bad_format_raises(self):
         """Test decoding using invalid jpeg format raises."""
-        index = get_indexed_datasets('1.2.840.10008.1.2.4.90')
-        ds = index['MR_small_jp2klossless.dcm']['ds']
+        index = get_indexed_datasets("1.2.840.10008.1.2.4.90")
+        ds = index["MR_small_jp2klossless.dcm"]["ds"]
         frame = next(generate_frames(ds))
 
         msg = r"Unsupported 'j2k_format' value: 3"
@@ -165,8 +165,8 @@ class TestDecode:
     @pytest.mark.skipif(not HAS_PYDICOM, reason="No pydicom")
     def test_decode_reshape_true(self):
         """Test decoding using invalid jpeg format raises."""
-        index = get_indexed_datasets('1.2.840.10008.1.2.4.90')
-        ds = index['US1_J2KR.dcm']['ds']
+        index = get_indexed_datasets("1.2.840.10008.1.2.4.90")
+        ds = index["US1_J2KR.dcm"]["ds"]
         frame = next(generate_frames(ds))
 
         arr = decode(frame)
@@ -175,32 +175,33 @@ class TestDecode:
 
         # Values checked against GDCM
         assert [
-            [180,  26,   0],
-            [172,  15,   0],
-            [162,   9,   0],
-            [152,   4,   0],
-            [145,   0,   0],
-            [132,   0,   0],
-            [119,   0,   0],
-            [106,   0,   0],
-            [ 87,   0,   0],
-            [ 37,   0,   0],
-            [  0,   0,   0],
-            [ 50,   0,   0],
-            [100,   0,   0],
-            [109,   0,   0],
-            [122,   0,   0],
-            [135,   0,   0],
-            [145,   0,   0],
-            [155,   5,   0],
-            [165,  11,   0],
-            [175,  17,   0]] == arr[175:195, 28, :].tolist()
+            [180, 26, 0],
+            [172, 15, 0],
+            [162, 9, 0],
+            [152, 4, 0],
+            [145, 0, 0],
+            [132, 0, 0],
+            [119, 0, 0],
+            [106, 0, 0],
+            [87, 0, 0],
+            [37, 0, 0],
+            [0, 0, 0],
+            [50, 0, 0],
+            [100, 0, 0],
+            [109, 0, 0],
+            [122, 0, 0],
+            [135, 0, 0],
+            [145, 0, 0],
+            [155, 5, 0],
+            [165, 11, 0],
+            [175, 17, 0],
+        ] == arr[175:195, 28, :].tolist()
 
     @pytest.mark.skipif(not HAS_PYDICOM, reason="No pydicom")
     def test_decode_reshape_false(self):
         """Test decoding using invalid jpeg format raises."""
-        index = get_indexed_datasets('1.2.840.10008.1.2.4.90')
-        ds = index['US1_J2KR.dcm']['ds']
+        index = get_indexed_datasets("1.2.840.10008.1.2.4.90")
+        ds = index["US1_J2KR.dcm"]["ds"]
         frame = next(generate_frames(ds))
 
         arr = decode(frame, reshape=False)
@@ -210,8 +211,8 @@ class TestDecode:
     @pytest.mark.skipif(not HAS_PYDICOM, reason="No pydicom")
     def test_signed_error(self):
         """Regression test for #30."""
-        index = get_indexed_datasets('1.2.840.10008.1.2.4.90')
-        ds = index['693_J2KR.dcm']['ds']
+        index = get_indexed_datasets("1.2.840.10008.1.2.4.90")
+        ds = index["693_J2KR.dcm"]["ds"]
         frame = next(generate_frames(ds))
 
         arr = decode(frame)
@@ -223,11 +224,11 @@ class TestDecode:
         # Component 2 is (2, 1)
         # Component 3 is (2, 1)
         jpg = DIR_15444 / "2KLS" / "oj36.j2k"
-        with open(jpg, 'rb') as f:
+        with open(jpg, "rb") as f:
             arr = decode(f.read())
 
         assert arr.flags.writeable
-        assert 'uint8' == arr.dtype
+        assert "uint8" == arr.dtype
         assert (256, 256, 3) == arr.shape
         assert [235, 244, 245] == arr[0, 0, :].tolist()
 
@@ -236,7 +237,16 @@ class TestDecode:
         d = DIR_15444 / "2KLS"
         arr = decode(d / "693.j2k")
         assert arr[270, 55:65].tolist() == [
-            340, 815, 1229, 1358, 1351, 1302, 1069, 618, 215, 71
+            340,
+            815,
+            1229,
+            1358,
+            1351,
+            1302,
+            1069,
+            618,
+            215,
+            71,
         ]
         arr = decode(d / "oj36.j2k")
         assert arr[60, 35:45].tolist() == [
@@ -258,9 +268,9 @@ class TestDecode:
 
         arr = decode(d / "Bretagne1_ht_lossy.j2k")
         assert arr[160, 295:305].tolist() == [
-            [ 91,  37,  2],
-            [ 94,  40,  1],
-            [ 97,  42,  5],
+            [91, 37, 2],
+            [94, 40, 1],
+            [97, 42, 5],
             [174, 123, 59],
             [172, 132, 69],
             [169, 134, 74],
@@ -284,9 +294,9 @@ class TestDecode:
 
         arr = decode(d / "Bretagne1_ht.j2k")
         assert arr[160, 295:305].tolist() == [
-            [ 90,  38,  1],
-            [ 94,  40,  1],
-            [ 97,  42,  5],
+            [90, 38, 1],
+            [94, 40, 1],
+            [97, 42, 5],
             [173, 122, 59],
             [172, 133, 69],
             [169, 135, 75],
@@ -316,19 +326,29 @@ class TestDecode:
             assert isinstance(buffer, bytearray)
             arr = np.frombuffer(buffer, dtype="i2").reshape((512, 512))
             assert arr[270, 55:65].tolist() == [
-                340, 815, 1229, 1358, 1351, 1302, 1069, 618, 215, 71
+                340,
+                815,
+                1229,
+                1358,
+                1351,
+                1302,
+                1069,
+                618,
+                215,
+                71,
             ]
 
 
 @pytest.mark.skipif(not HAS_PYDICOM, reason="No pydicom")
 class TestDecodeDCM:
     """Tests for get_parameters() using DICOM datasets."""
-    @pytest.mark.parametrize("fname, info", REF_DCM['1.2.840.10008.1.2.4.90'])
+
+    @pytest.mark.parametrize("fname, info", REF_DCM["1.2.840.10008.1.2.4.90"])
     def test_jpeg2000r(self, fname, info):
         """Test get_parameters() for the j2k lossless datasets."""
-        #info: (rows, columns, spp, bps)
-        index = get_indexed_datasets('1.2.840.10008.1.2.4.90')
-        ds = index[fname]['ds']
+        # info: (rows, columns, spp, bps)
+        index = get_indexed_datasets("1.2.840.10008.1.2.4.90")
+        ds = index[fname]["ds"]
         frame = next(generate_frames(ds))
         arr = decode(BytesIO(frame), reshape=False)
         assert arr.flags.writeable
@@ -337,8 +357,8 @@ class TestDecodeDCM:
         arr = arr.view(pixel_dtype(ds))
         arr = reshape_pixel_array(ds, arr)
 
-        #plt.imshow(arr)
-        #plt.show()
+        # plt.imshow(arr)
+        # plt.show()
 
         if info[2] == 1:
             assert (info[0], info[1]) == arr.shape
@@ -347,21 +367,21 @@ class TestDecodeDCM:
 
         if 1 <= info[3] <= 8:
             if info[4] == 1:
-                assert arr.dtype == 'int8'
+                assert arr.dtype == "int8"
             else:
-                assert arr.dtype == 'uint8'
+                assert arr.dtype == "uint8"
         if 9 <= info[3] <= 16:
             if info[4] == 1:
-                assert arr.dtype == 'int16'
+                assert arr.dtype == "int16"
             else:
-                assert arr.dtype == 'uint16'
+                assert arr.dtype == "uint16"
 
-    @pytest.mark.parametrize("fname, info", REF_DCM['1.2.840.10008.1.2.4.91'])
+    @pytest.mark.parametrize("fname, info", REF_DCM["1.2.840.10008.1.2.4.91"])
     def test_jpeg2000i(self, fname, info):
         """Test get_parameters() for the j2k datasets."""
-        #info: (rows, columns, spp, bps)
-        index = get_indexed_datasets('1.2.840.10008.1.2.4.91')
-        ds = index[fname]['ds']
+        # info: (rows, columns, spp, bps)
+        index = get_indexed_datasets("1.2.840.10008.1.2.4.91")
+        ds = index[fname]["ds"]
 
         frame = next(generate_frames(ds))
         arr = decode(BytesIO(frame), reshape=False)
@@ -371,8 +391,8 @@ class TestDecodeDCM:
         arr = arr.view(pixel_dtype(ds))
         arr = reshape_pixel_array(ds, arr)
 
-        #plt.imshow(arr)
-        #plt.show()
+        # plt.imshow(arr)
+        # plt.show()
 
         if info[2] == 1:
             assert (info[0], info[1]) == arr.shape
@@ -381,11 +401,11 @@ class TestDecodeDCM:
 
         if 1 <= info[3] <= 8:
             if info[4] == 1:
-                assert arr.dtype == 'int8'
+                assert arr.dtype == "int8"
             else:
-                assert arr.dtype == 'uint8'
+                assert arr.dtype == "uint8"
         if 9 <= info[3] <= 16:
             if info[4] == 1:
-                assert arr.dtype == 'int16'
+                assert arr.dtype == "int16"
             else:
-                assert arr.dtype == 'uint16'
+                assert arr.dtype == "uint16"

--- a/openjpeg/tests/test_decode.py
+++ b/openjpeg/tests/test_decode.py
@@ -22,6 +22,7 @@ from openjpeg.utils import (
     decode,
     get_parameters,
     decode_pixel_data,
+    _get_format,
 )
 
 
@@ -76,6 +77,14 @@ def generate_frames(ds):
     """Return a frame generator for DICOM datasets."""
     nr_frames = ds.get('NumberOfFrames', 1)
     return generate_pixel_data_frame(ds.PixelData, nr_frames)
+
+
+def test_get_format_raises():
+    """Test get_format() raises for an unknown magic number"""
+    buffer = BytesIO(b"\x00" * 20)
+    msg = "No matching JPEG 2000 format found"
+    with pytest.raises(ValueError, match=msg):
+        _get_format(buffer)
 
 
 @pytest.mark.skipif(not HAS_PYDICOM, reason="No pydicom")

--- a/openjpeg/tests/test_handler.py
+++ b/openjpeg/tests/test_handler.py
@@ -1,55 +1,53 @@
 """Tests for the pylibjpeg pixel data handler."""
 
 import pytest
-import warnings
-
-import numpy as np
 
 try:
-    import pydicom
-    import pydicom.config
     from pydicom.encaps import generate_pixel_data_frame
+
     HAS_PYDICOM = True
 except ImportError:
     HAS_PYDICOM = False
 
-from openjpeg import decode, get_parameters, decode_pixel_data
+from openjpeg import get_parameters, decode_pixel_data
 from openjpeg.data import get_indexed_datasets
 
 
 def generate_frames(ds):
     """Return a frame generator for DICOM datasets."""
-    nr_frames = ds.get('NumberOfFrames', 1)
+    nr_frames = ds.get("NumberOfFrames", 1)
     return generate_pixel_data_frame(ds.PixelData, nr_frames)
 
 
 @pytest.mark.skipif(not HAS_PYDICOM, reason="pydicom unavailable")
 class TestHandler:
     """Tests for the pixel data handler."""
+
     def test_invalid_type_raises(self):
         """Test decoding using invalid type raises."""
-        index = get_indexed_datasets('1.2.840.10008.1.2.4.90')
-        ds = index['MR_small_jp2klossless.dcm']['ds']
+        index = get_indexed_datasets("1.2.840.10008.1.2.4.90")
+        ds = index["MR_small_jp2klossless.dcm"]["ds"]
         frame = tuple(next(generate_frames(ds)))
-        assert not hasattr(frame, 'tell') and not isinstance(frame, bytes)
+        assert not hasattr(frame, "tell") and not isinstance(frame, bytes)
 
         msg = "a bytes-like object is required, not 'tuple'"
         with pytest.raises(TypeError, match=msg):
             decode_pixel_data(frame)
 
     def test_no_dataset(self):
-        index = get_indexed_datasets('1.2.840.10008.1.2.4.90')
-        ds = index['MR_small_jp2klossless.dcm']['ds']
+        index = get_indexed_datasets("1.2.840.10008.1.2.4.90")
+        ds = index["MR_small_jp2klossless.dcm"]["ds"]
         frame = next(generate_frames(ds))
         arr = decode_pixel_data(frame)
         assert arr.flags.writeable
-        assert 'uint8' == arr.dtype
+        assert "uint8" == arr.dtype
         length = ds.Rows * ds.Columns * ds.SamplesPerPixel * ds.BitsAllocated / 8
         assert (length,) == arr.shape
 
 
 class HandlerTestBase:
     """Baseclass for handler tests."""
+
     uid = None
 
     def setup_method(self):
@@ -75,20 +73,21 @@ class HandlerTestBase:
 @pytest.mark.skipif(not HAS_PYDICOM, reason="No dependencies")
 class TestLibrary:
     """Tests for libjpeg itself."""
+
     def test_non_conformant_raises(self):
         """Test that a non-conformant JPEG image raises an exception."""
-        ds_list = get_indexed_datasets('1.2.840.10008.1.2.4.90')
+        ds_list = get_indexed_datasets("1.2.840.10008.1.2.4.90")
         # Image has invalid Se value in the SOS marker segment
-        item = ds_list['966.dcm']
-        assert 0xC000 == item['Status'][1]
+        item = ds_list["966.dcm"]
+        assert 0xC000 == item["Status"][1]
         msg = r"Error decoding the J2K data: failed to decode image"
         with pytest.raises(RuntimeError, match=msg):
-            item['ds'].pixel_array
+            item["ds"].pixel_array
 
     def test_invalid_pixel_representation(self):
         """Test that warning issued when Pixel Representation doesn't match."""
-        index = get_indexed_datasets('1.2.840.10008.1.2.4.90')
-        ds = index['TOSHIBA_J2K_SIZ0_PixRep1.dcm']['ds']
+        index = get_indexed_datasets("1.2.840.10008.1.2.4.90")
+        ds = index["TOSHIBA_J2K_SIZ0_PixRep1.dcm"]["ds"]
         msg = (
             r"The \(0028,0103\) Pixel Representation value '1' \(signed\) in "
             r"the dataset does not match the format of the values found in "
@@ -99,8 +98,8 @@ class TestLibrary:
 
     def test_invalid_bits_stored(self):
         """Test that warning issued when Bits Stored doesn't match."""
-        index = get_indexed_datasets('1.2.840.10008.1.2.4.91')
-        ds = index['OsirixFake16BitsStoredFakeSpacing.dcm']['ds']
+        index = get_indexed_datasets("1.2.840.10008.1.2.4.91")
+        ds = index["OsirixFake16BitsStoredFakeSpacing.dcm"]["ds"]
         msg = (
             r"The \(0028,0101\) Bits Stored value '16' in the dataset does "
             r"not match the component precision value '11' found in the JPEG "
@@ -112,8 +111,8 @@ class TestLibrary:
 
     def test_invalid_samples_per_pixel(self):
         """Test that warning issued when Samples Per Pixel doesn't match."""
-        index = get_indexed_datasets('1.2.840.10008.1.2.4.90')
-        ds = index['693_J2KR.dcm']['ds']
+        index = get_indexed_datasets("1.2.840.10008.1.2.4.90")
+        ds = index["693_J2KR.dcm"]["ds"]
         ds.SamplesPerPixel = 3
         msg = (
             r"The \(0028,0002\) Samples per Pixel value '3' in the dataset "
@@ -127,8 +126,8 @@ class TestLibrary:
 
     def test_invalid_pixel_data(self):
         """Test that warning issued if Pixel Data is not a J2K codestream."""
-        index = get_indexed_datasets('1.2.840.10008.1.2.4.90')
-        ds = index['GDCMJ2K_TextGBR.dcm']['ds']
+        index = get_indexed_datasets("1.2.840.10008.1.2.4.90")
+        ds = index["GDCMJ2K_TextGBR.dcm"]["ds"]
         msg = (
             r"The \(7FE0,0010\) Pixel Data contains a JPEG 2000 codestream "
             r"with the optional JP2 file format header, which is "
@@ -139,8 +138,8 @@ class TestLibrary:
 
     def test_valid_no_warning(self, recwarn):
         """Test no warning issued when dataset matches JPEG data."""
-        index = get_indexed_datasets('1.2.840.10008.1.2.4.90')
-        ds = index['966_fixed.dcm']['ds']
+        index = get_indexed_datasets("1.2.840.10008.1.2.4.90")
+        ds = index["966_fixed.dcm"]["ds"]
         ds.pixel_array
 
         assert len(recwarn) == 0
@@ -153,15 +152,16 @@ class TestJPEGBaseline(HandlerTestBase):
 
     1.2.840.10008.1.2.4.50 : JPEG Baseline (Process 1)
     """
-    uid = '1.2.840.10008.1.2.4.50'
+
+    uid = "1.2.840.10008.1.2.4.50"
 
     def test_raises(self):
         """Test greyscale."""
-        ds = self.ds['JPEGBaseline_1s_1f_u_08_08.dcm']['ds']
+        ds = self.ds["JPEGBaseline_1s_1f_u_08_08.dcm"]["ds"]
         assert self.uid == ds.file_meta.TransferSyntaxUID
         assert 1 == ds.SamplesPerPixel
-        assert 1 == getattr(ds, 'NumberOfFrames', 1)
-        assert 'MONOCHROME' in ds.PhotometricInterpretation
+        assert 1 == getattr(ds, "NumberOfFrames", 1)
+        assert "MONOCHROME" in ds.PhotometricInterpretation
         assert 8 == ds.BitsAllocated == ds.BitsStored
         assert 0 == ds.PixelRepresentation
 
@@ -179,16 +179,17 @@ class TestJPEGExtended(HandlerTestBase):
 
     1.2.840.10008.1.2.4.51 : JPEG Extended (Process 2 and 4)
     """
-    uid = '1.2.840.10008.1.2.4.51'
+
+    uid = "1.2.840.10008.1.2.4.51"
 
     # Process 4
     def test_raises(self):
         """Test process 4 greyscale."""
-        ds = self.ds['RG2_JPLY_fixed.dcm']['ds']
+        ds = self.ds["RG2_JPLY_fixed.dcm"]["ds"]
         assert self.uid == ds.file_meta.TransferSyntaxUID
         assert 1 == ds.SamplesPerPixel
-        assert 1 == getattr(ds, 'NumberOfFrames', 1)
-        assert 'MONOCHROME' in ds.PhotometricInterpretation
+        assert 1 == getattr(ds, "NumberOfFrames", 1)
+        assert "MONOCHROME" in ds.PhotometricInterpretation
         assert 16 == ds.BitsAllocated
         # Input precision is 12, not 10
         assert 10 == ds.BitsStored
@@ -208,15 +209,16 @@ class TestJPEGLossless(HandlerTestBase):
 
     1.2.840.10008.1.2.4.57 : JPEG Lossless, Non-Hierarchical (Process 14)
     """
-    uid = '1.2.840.10008.1.2.4.57'
+
+    uid = "1.2.840.10008.1.2.4.57"
 
     def test_raises(self):
         """Test process 2 greyscale."""
-        ds = self.ds['JPEGLossless_1s_1f_u_16_12.dcm']['ds']
+        ds = self.ds["JPEGLossless_1s_1f_u_16_12.dcm"]["ds"]
         assert self.uid == ds.file_meta.TransferSyntaxUID
         assert 1 == ds.SamplesPerPixel
-        assert 1 == getattr(ds, 'NumberOfFrames', 1)
-        assert 'MONOCHROME' in ds.PhotometricInterpretation
+        assert 1 == getattr(ds, "NumberOfFrames", 1)
+        assert "MONOCHROME" in ds.PhotometricInterpretation
         assert 16 == ds.BitsAllocated
         assert 12 == ds.BitsStored
         assert 0 == ds.PixelRepresentation
@@ -236,15 +238,16 @@ class TestJPEGLosslessSV1(HandlerTestBase):
     1.2.840.10008.1.2.4.70 : JPEG Lossless, Non-Hierarchical, First-Order
     Prediction (Process 14 [Selection Value 1]
     """
-    uid = '1.2.840.10008.1.2.4.70'
+
+    uid = "1.2.840.10008.1.2.4.70"
 
     def test_raises(self):
         """Test process 2 greyscale."""
-        ds = self.ds['JPEGLosslessP14SV1_1s_1f_u_08_08.dcm']['ds']
+        ds = self.ds["JPEGLosslessP14SV1_1s_1f_u_08_08.dcm"]["ds"]
         assert self.uid == ds.file_meta.TransferSyntaxUID
         assert 1 == ds.SamplesPerPixel
-        assert 1 == getattr(ds, 'NumberOfFrames', 1)
-        assert 'MONOCHROME' in ds.PhotometricInterpretation
+        assert 1 == getattr(ds, "NumberOfFrames", 1)
+        assert "MONOCHROME" in ds.PhotometricInterpretation
         assert 8 == ds.BitsAllocated
         assert 8 == ds.BitsStored
         assert 0 == ds.PixelRepresentation
@@ -264,15 +267,16 @@ class TestJPEGLSLossless(HandlerTestBase):
 
     1.2.840.10008.1.2.4.80 : JPEG-LS Lossless Image Compression
     """
-    uid = '1.2.840.10008.1.2.4.80'
+
+    uid = "1.2.840.10008.1.2.4.80"
 
     def test_raises(self):
         """Test process 2 greyscale."""
-        ds = self.ds['MR_small_jpeg_ls_lossless.dcm']['ds']
+        ds = self.ds["MR_small_jpeg_ls_lossless.dcm"]["ds"]
         assert self.uid == ds.file_meta.TransferSyntaxUID
         assert 1 == ds.SamplesPerPixel
-        assert 1 == getattr(ds, 'NumberOfFrames', 1)
-        assert 'MONOCHROME' in ds.PhotometricInterpretation
+        assert 1 == getattr(ds, "NumberOfFrames", 1)
+        assert "MONOCHROME" in ds.PhotometricInterpretation
         assert 16 == ds.BitsAllocated
         assert 16 == ds.BitsStored
         assert 1 == ds.PixelRepresentation
@@ -291,15 +295,16 @@ class TestJPEGLS(HandlerTestBase):
 
     1.2.840.10008.1.2.4.81 : JPEG-LS Lossy (Near-Lossless) Image Compression
     """
-    uid = '1.2.840.10008.1.2.4.81'
+
+    uid = "1.2.840.10008.1.2.4.81"
 
     def test_raises(self):
         """Test process 2 greyscale."""
-        ds = self.ds['CT1_JLSN.dcm']['ds']
+        ds = self.ds["CT1_JLSN.dcm"]["ds"]
         assert self.uid == ds.file_meta.TransferSyntaxUID
         assert 1 == ds.SamplesPerPixel
-        assert 1 == getattr(ds, 'NumberOfFrames', 1)
-        assert 'MONOCHROME' in ds.PhotometricInterpretation
+        assert 1 == getattr(ds, "NumberOfFrames", 1)
+        assert "MONOCHROME" in ds.PhotometricInterpretation
         assert 16 == ds.BitsAllocated
         assert 16 == ds.BitsStored
         assert 1 == ds.PixelRepresentation
@@ -319,122 +324,124 @@ class TestJPEG2000Lossless(HandlerTestBase):
 
     1.2.840.10008.1.2.4.90 : JPEG 2000 Image Compression (Lossless Only)
     """
-    uid = '1.2.840.10008.1.2.4.90'
+
+    uid = "1.2.840.10008.1.2.4.90"
 
     @pytest.mark.skip("No suitable dataset")
     def test_1s_1f_i_08_08(self):
         """Test 1 component, 1 frame, signed 8-bit."""
-        ds = self.ds['.dcm']['ds']
+        ds = self.ds[".dcm"]["ds"]
         assert self.uid == ds.file_meta.TransferSyntaxUID
         assert 1 == ds.SamplesPerPixel
-        assert 1 == getattr(ds, 'NumberOfFrames', 1)
-        assert 'MONOCHROME' in ds.PhotometricInterpretation
+        assert 1 == getattr(ds, "NumberOfFrames", 1)
+        assert "MONOCHROME" in ds.PhotometricInterpretation
         assert 8 == ds.BitsAllocated
         assert 8 == ds.BitsStored
         assert 1 == ds.PixelRepresentation
 
         arr = ds.pixel_array
         assert arr.flags.writeable
-        assert 'int8' == arr.dtype
+        assert "int8" == arr.dtype
         assert (ds.Rows, ds.Columns) == arr.shape
 
     @pytest.mark.skip("No suitable dataset")
     def test_1s_1f_u_08_08(self):
         """Test 1 component, 1 frame, unsigned 8-bit."""
-        ds = self.ds['.dcm']['ds']
+        ds = self.ds[".dcm"]["ds"]
         assert self.uid == ds.file_meta.TransferSyntaxUID
         assert 1 == ds.SamplesPerPixel
-        assert 1 == getattr(ds, 'NumberOfFrames', 1)
-        assert 'MONOCHROME' in ds.PhotometricInterpretation
+        assert 1 == getattr(ds, "NumberOfFrames", 1)
+        assert "MONOCHROME" in ds.PhotometricInterpretation
         assert 8 == ds.BitsAllocated
         assert 8 == ds.BitsStored
         assert 0 == ds.PixelRepresentation
 
         arr = ds.pixel_array
         assert arr.flags.writeable
-        assert 'int8' == arr.dtype
+        assert "int8" == arr.dtype
         assert (ds.Rows, ds.Columns) == arr.shape
 
     @pytest.mark.skip("No suitable dataset")
     def test_1s_2f_i_08_08(self):
         """Test 1 component, 2 frame, signed 8-bit."""
-        ds = self.ds['.dcm']['ds']
+        ds = self.ds[".dcm"]["ds"]
         assert self.uid == ds.file_meta.TransferSyntaxUID
         assert 1 == ds.SamplesPerPixel
-        assert 2 == getattr(ds, 'NumberOfFrames', 1)
-        assert 'MONOCHROME' in ds.PhotometricInterpretation
+        assert 2 == getattr(ds, "NumberOfFrames", 1)
+        assert "MONOCHROME" in ds.PhotometricInterpretation
         assert 8 == ds.BitsAllocated
         assert 8 == ds.BitsStored
         assert 1 == ds.PixelRepresentation
 
         arr = ds.pixel_array
         assert arr.flags.writeable
-        assert 'int8' == arr.dtype
+        assert "int8" == arr.dtype
         assert (ds.Rows, ds.Columns) == arr.shape
 
     def test_3s_1f_u_08_08(self):
         """Test 3 component, 1 frame, unsigned 8-bit."""
-        ds = self.ds['US1_J2KR.dcm']['ds']
+        ds = self.ds["US1_J2KR.dcm"]["ds"]
         assert self.uid == ds.file_meta.TransferSyntaxUID
         assert 3 == ds.SamplesPerPixel
-        assert 1 == getattr(ds, 'NumberOfFrames', 1)
-        assert 'YBR_RCT' in ds.PhotometricInterpretation
+        assert 1 == getattr(ds, "NumberOfFrames", 1)
+        assert "YBR_RCT" in ds.PhotometricInterpretation
         assert 8 == ds.BitsAllocated
         assert 8 == ds.BitsStored
         assert 0 == ds.PixelRepresentation
 
         arr = ds.pixel_array
         assert arr.flags.writeable
-        assert 'uint8' == arr.dtype
+        assert "uint8" == arr.dtype
         assert (ds.Rows, ds.Columns, ds.SamplesPerPixel) == arr.shape
 
         # Values checked against GDCM
         assert [
-            [180,  26,   0],
-            [172,  15,   0],
-            [162,   9,   0],
-            [152,   4,   0],
-            [145,   0,   0],
-            [132,   0,   0],
-            [119,   0,   0],
-            [106,   0,   0],
-            [ 87,   0,   0],
-            [ 37,   0,   0],
-            [  0,   0,   0],
-            [ 50,   0,   0],
-            [100,   0,   0],
-            [109,   0,   0],
-            [122,   0,   0],
-            [135,   0,   0],
-            [145,   0,   0],
-            [155,   5,   0],
-            [165,  11,   0],
-            [175,  17,   0]] == arr[175:195, 28, :].tolist()
+            [180, 26, 0],
+            [172, 15, 0],
+            [162, 9, 0],
+            [152, 4, 0],
+            [145, 0, 0],
+            [132, 0, 0],
+            [119, 0, 0],
+            [106, 0, 0],
+            [87, 0, 0],
+            [37, 0, 0],
+            [0, 0, 0],
+            [50, 0, 0],
+            [100, 0, 0],
+            [109, 0, 0],
+            [122, 0, 0],
+            [135, 0, 0],
+            [145, 0, 0],
+            [155, 5, 0],
+            [165, 11, 0],
+            [175, 17, 0],
+        ] == arr[175:195, 28, :].tolist()
 
     @pytest.mark.skip("No suitable dataset")
     def test_3s_2f_i_08_08(self):
         """Test 3 component, 2 frame, signed 8-bit."""
-        ds = self.ds['.dcm']['ds']
+        ds = self.ds[".dcm"]["ds"]
         assert self.uid == ds.file_meta.TransferSyntaxUID
         assert 1 == ds.SamplesPerPixel
-        assert 1 == getattr(ds, 'NumberOfFrames', 1)
-        assert 'RGB' in ds.PhotometricInterpretation
+        assert 1 == getattr(ds, "NumberOfFrames", 1)
+        assert "RGB" in ds.PhotometricInterpretation
         assert 8 == ds.BitsAllocated
         assert 8 == ds.BitsStored
         assert 1 == ds.PixelRepresentation
 
         arr = ds.pixel_array
         assert arr.flags.writeable
-        assert 'uint8' == arr.dtype
+        assert "uint8" == arr.dtype
         assert (ds.Rows, ds.Columns, ds.SamplesPerPixel) == arr.shape
 
     def test_1s_1f_i_16_14(self):
         """Test 1 component, 1 frame, signed 16/14-bit."""
-        ds = self.ds['693_J2KR.dcm']['ds']
+        ds = self.ds["693_J2KR.dcm"]["ds"]
         assert self.uid == ds.file_meta.TransferSyntaxUID
         assert 1 == ds.SamplesPerPixel
-        assert 1 == getattr(ds, 'NumberOfFrames', 1)
-        assert 'MONOCHROME' in ds.PhotometricInterpretation
+        assert 1 == getattr(ds, "NumberOfFrames", 1)
+        assert "MONOCHROME" in ds.PhotometricInterpretation
         assert 16 == ds.BitsAllocated
         # assert 14 == ds.BitsStored   # wrong bits stored value - should warn?
         assert 1 == ds.PixelRepresentation
@@ -446,45 +453,43 @@ class TestJPEG2000Lossless(HandlerTestBase):
         with pytest.warns(UserWarning, match=msg):
             arr = ds.pixel_array
         assert arr.flags.writeable
-        assert 'int16' == arr.dtype
+        assert "int16" == arr.dtype
         assert (ds.Rows, ds.Columns) == arr.shape
 
         # Values checked against GDCM
-        assert (
-            [1022, 1051, 1165, 1442, 1835, 2096, 2074, 1868, 1685, 1603] ==
-            arr[290, 135:145].tolist()
-        )
+        assert [1022, 1051, 1165, 1442, 1835, 2096, 2074, 1868, 1685, 1603] == arr[
+            290, 135:145
+        ].tolist()
         assert -2000 == arr[0, 0]
 
     def test_1s_1f_i_16_16(self):
         """Test 1 component, 1 frame, signed 16/16-bit."""
-        ds = self.ds['explicit_VR-UN.dcm']['ds']
+        ds = self.ds["explicit_VR-UN.dcm"]["ds"]
         assert self.uid == ds.file_meta.TransferSyntaxUID
         assert 1 == ds.SamplesPerPixel
-        assert 1 == getattr(ds, 'NumberOfFrames', 1)
-        assert 'MONOCHROME' in ds.PhotometricInterpretation
+        assert 1 == getattr(ds, "NumberOfFrames", 1)
+        assert "MONOCHROME" in ds.PhotometricInterpretation
         assert 16 == ds.BitsAllocated
         assert 16 == ds.BitsStored
         assert 1 == ds.PixelRepresentation
 
         arr = ds.pixel_array
         assert arr.flags.writeable
-        assert 'int16' == arr.dtype
+        assert "int16" == arr.dtype
         assert (ds.Rows, ds.Columns) == arr.shape
 
         # Values checked against GDCM
-        assert (
-            [ 21, 287, 797, 863, 813, 428,  55,  -7,  37, -22] ==
-            arr[142, 260:270].tolist()
-        )
+        assert [21, 287, 797, 863, 813, 428, 55, -7, 37, -22] == arr[
+            142, 260:270
+        ].tolist()
 
     def test_1s_1f_u_16_12(self):
         """Test 1 component, 1 frame, unsigned 16/12-bit."""
-        ds = self.ds['NM_Kakadu44_SOTmarkerincons.dcm']['ds']
+        ds = self.ds["NM_Kakadu44_SOTmarkerincons.dcm"]["ds"]
         assert self.uid == ds.file_meta.TransferSyntaxUID
         assert 1 == ds.SamplesPerPixel
-        assert 1 == getattr(ds, 'NumberOfFrames', 1)
-        assert 'MONOCHROME' in ds.PhotometricInterpretation
+        assert 1 == getattr(ds, "NumberOfFrames", 1)
+        assert "MONOCHROME" in ds.PhotometricInterpretation
         assert 16 == ds.BitsAllocated
         assert 12 == ds.BitsStored
         assert 0 == ds.PixelRepresentation
@@ -496,66 +501,63 @@ class TestJPEG2000Lossless(HandlerTestBase):
         with pytest.warns(UserWarning, match=msg):
             arr = ds.pixel_array
         assert arr.flags.writeable
-        assert 'uint16' == arr.dtype
+        assert "uint16" == arr.dtype
         assert (ds.Rows, ds.Columns) == arr.shape
 
         # Values checked against GDCM
-        assert (
-            [2719, 2678, 2684, 2719, 2882, 2963, 2981, 2949, 3049, 3145] ==
-            arr[2417, 1223:1233].tolist()
-        )
+        assert [2719, 2678, 2684, 2719, 2882, 2963, 2981, 2949, 3049, 3145] == arr[
+            2417, 1223:1233
+        ].tolist()
 
     def test_1s_1f_u_16_15(self):
         """Test 1 component, 1 frame, unsigned 16/15-bit."""
-        ds = self.ds['RG1_J2KR.dcm']['ds']
+        ds = self.ds["RG1_J2KR.dcm"]["ds"]
         assert self.uid == ds.file_meta.TransferSyntaxUID
         assert 1 == ds.SamplesPerPixel
-        assert 1 == getattr(ds, 'NumberOfFrames', 1)
-        assert 'MONOCHROME' in ds.PhotometricInterpretation
+        assert 1 == getattr(ds, "NumberOfFrames", 1)
+        assert "MONOCHROME" in ds.PhotometricInterpretation
         assert 16 == ds.BitsAllocated
         assert 15 == ds.BitsStored
         assert 0 == ds.PixelRepresentation
 
         arr = ds.pixel_array
         assert arr.flags.writeable
-        assert 'uint16' == arr.dtype
+        assert "uint16" == arr.dtype
         assert (ds.Rows, ds.Columns) == arr.shape
 
         # Values checked against GDCM
-        assert (
-            [21920, 22082, 22245, 22406, 22557, 22619, 22629, 22724, 22787] ==
-            arr[45:54, 184].tolist()
-        )
+        assert [21920, 22082, 22245, 22406, 22557, 22619, 22629, 22724, 22787] == arr[
+            45:54, 184
+        ].tolist()
 
     def test_1s_1f_u_16_16(self):
         """Test 1 component, 1 frame, unsigned 16/16-bit."""
-        ds = self.ds['JPEG2KLossless_1s_1f_u_16_16.dcm']['ds']
+        ds = self.ds["JPEG2KLossless_1s_1f_u_16_16.dcm"]["ds"]
         assert self.uid == ds.file_meta.TransferSyntaxUID
         assert 1 == ds.SamplesPerPixel
-        assert 1 == getattr(ds, 'NumberOfFrames', 1)
-        assert 'MONOCHROME' in ds.PhotometricInterpretation
+        assert 1 == getattr(ds, "NumberOfFrames", 1)
+        assert "MONOCHROME" in ds.PhotometricInterpretation
         assert 16 == ds.BitsAllocated
         assert 16 == ds.BitsStored
         assert 0 == ds.PixelRepresentation
 
         arr = ds.pixel_array
         assert arr.flags.writeable
-        assert 'uint16' == arr.dtype
+        assert "uint16" == arr.dtype
         assert (ds.Rows, ds.Columns) == arr.shape
 
         # Values checked against GDCM
-        assert (
-            [55680, 57220, 58518, 61083, 64624, 65535, 65535, 65535, 65535] ==
-            arr[1402:1411, 1388].tolist()
-        )
+        assert [55680, 57220, 58518, 61083, 64624, 65535, 65535, 65535, 65535] == arr[
+            1402:1411, 1388
+        ].tolist()
 
     def test_1s_10f_u_16_16(self):
         """Test 1 component, 10 frame, unsigned 16/16-bit."""
-        ds = self.ds['emri_small_jpeg_2k_lossless.dcm']['ds']
+        ds = self.ds["emri_small_jpeg_2k_lossless.dcm"]["ds"]
         assert self.uid == ds.file_meta.TransferSyntaxUID
         assert 1 == ds.SamplesPerPixel
-        assert 10 == getattr(ds, 'NumberOfFrames', 1)
-        assert 'MONOCHROME' in ds.PhotometricInterpretation
+        assert 10 == getattr(ds, "NumberOfFrames", 1)
+        assert "MONOCHROME" in ds.PhotometricInterpretation
         assert 16 == ds.BitsAllocated
         assert 12 == ds.BitsStored  # wrong bits stored value
         assert 0 == ds.PixelRepresentation
@@ -567,27 +569,25 @@ class TestJPEG2000Lossless(HandlerTestBase):
         with pytest.warns(UserWarning, match=msg):
             arr = ds.pixel_array
         assert arr.flags.writeable
-        assert 'uint16' == arr.dtype
+        assert "uint16" == arr.dtype
         assert (ds.NumberOfFrames, ds.Rows, ds.Columns) == arr.shape
 
         # Values checked against GDCM
-        assert (
-            [290, 312, 345, 414, 379, 239, 119,  76,  80,  76] ==
-            arr[0, 36, 41:51].tolist()
-        )
-        assert (
-            [ 87,  45, 193, 341, 307, 133,  54,  99, 113, 101] ==
-            arr[9, 53:63, 57].tolist()
-        )
+        assert [290, 312, 345, 414, 379, 239, 119, 76, 80, 76] == arr[
+            0, 36, 41:51
+        ].tolist()
+        assert [87, 45, 193, 341, 307, 133, 54, 99, 113, 101] == arr[
+            9, 53:63, 57
+        ].tolist()
 
     @pytest.mark.skip("No suitable dataset")
     def test_1s_2f_i_16_16(self):
         """Test 1 component, 2 frame, signed 16/16-bit."""
-        ds = self.ds['.dcm']['ds']
+        ds = self.ds[".dcm"]["ds"]
         assert self.uid == ds.file_meta.TransferSyntaxUID
         assert 1 == ds.SamplesPerPixel
-        assert 1 == getattr(ds, 'NumberOfFrames', 1)
-        assert 'MONOCHROME' in ds.PhotometricInterpretation
+        assert 1 == getattr(ds, "NumberOfFrames", 1)
+        assert "MONOCHROME" in ds.PhotometricInterpretation
         assert 16 == ds.BitsAllocated
         assert 16 == ds.BitsStored
         assert 1 == ds.PixelRepresentation
@@ -595,11 +595,11 @@ class TestJPEG2000Lossless(HandlerTestBase):
     @pytest.mark.skip("No suitable dataset")
     def test_3s_1f_i_16_16(self):
         """Test 3 component, 1 frame, signed 16/16-bit."""
-        ds = self.ds['.dcm']['ds']
+        ds = self.ds[".dcm"]["ds"]
         assert self.uid == ds.file_meta.TransferSyntaxUID
         assert 1 == ds.SamplesPerPixel
-        assert 1 == getattr(ds, 'NumberOfFrames', 1)
-        assert 'MONOCHROME' in ds.PhotometricInterpretation
+        assert 1 == getattr(ds, "NumberOfFrames", 1)
+        assert "MONOCHROME" in ds.PhotometricInterpretation
         assert 16 == ds.BitsAllocated
         assert 16 == ds.BitsStored
         assert 1 == ds.PixelRepresentation
@@ -607,22 +607,22 @@ class TestJPEG2000Lossless(HandlerTestBase):
     @pytest.mark.skip("No suitable dataset")
     def test_3s_2f_i_16_16(self):
         """Test 3 component, 2 frame, signed 16/16-bit."""
-        ds = self.ds['.dcm']['ds']
+        ds = self.ds[".dcm"]["ds"]
         assert self.uid == ds.file_meta.TransferSyntaxUID
         assert 1 == ds.SamplesPerPixel
-        assert 1 == getattr(ds, 'NumberOfFrames', 1)
-        assert 'MONOCHROME' in ds.PhotometricInterpretation
+        assert 1 == getattr(ds, "NumberOfFrames", 1)
+        assert "MONOCHROME" in ds.PhotometricInterpretation
         assert 16 == ds.BitsAllocated
         assert 16 == ds.BitsStored
         assert 1 == ds.PixelRepresentation
 
     def test_jp2(self):
         """Test decoding a non-conformant Pixel Data with JP2 data."""
-        ds = self.ds['GDCMJ2K_TextGBR.dcm']['ds']
+        ds = self.ds["GDCMJ2K_TextGBR.dcm"]["ds"]
         assert self.uid == ds.file_meta.TransferSyntaxUID
         assert 3 == ds.SamplesPerPixel
-        assert 1 == getattr(ds, 'NumberOfFrames', 1)
-        assert 'YBR_RCT' in ds.PhotometricInterpretation
+        assert 1 == getattr(ds, "NumberOfFrames", 1)
+        assert "YBR_RCT" in ds.PhotometricInterpretation
         assert 8 == ds.BitsAllocated
         assert 8 == ds.BitsStored
         assert 0 == ds.PixelRepresentation
@@ -634,7 +634,7 @@ class TestJPEG2000Lossless(HandlerTestBase):
         with pytest.warns(UserWarning, match=msg):
             arr = ds.pixel_array
         assert arr.flags.writeable
-        assert 'uint8' == arr.dtype
+        assert "uint8" == arr.dtype
         assert (ds.Rows, ds.Columns, ds.SamplesPerPixel) == arr.shape
 
         # Values checked against GDCM
@@ -645,11 +645,11 @@ class TestJPEG2000Lossless(HandlerTestBase):
 
     def test_data_unsigned_pr_1(self):
         """Test unsigned JPEG data with Pixel Representation 1"""
-        ds = self.ds['TOSHIBA_J2K_SIZ0_PixRep1.dcm']['ds']
+        ds = self.ds["TOSHIBA_J2K_SIZ0_PixRep1.dcm"]["ds"]
         assert self.uid == ds.file_meta.TransferSyntaxUID
         assert 1 == ds.SamplesPerPixel
-        assert 1 == getattr(ds, 'NumberOfFrames', 1)
-        assert 'MONOCHROME' in ds.PhotometricInterpretation
+        assert 1 == getattr(ds, "NumberOfFrames", 1)
+        assert "MONOCHROME" in ds.PhotometricInterpretation
         assert 16 == ds.BitsAllocated
         assert 16 == ds.BitsStored
         assert 1 == ds.PixelRepresentation
@@ -662,21 +662,21 @@ class TestJPEG2000Lossless(HandlerTestBase):
             r"'unsigned'"
         )
         with pytest.warns(UserWarning, match=msg):
-            arr = ds.pixel_array
+            ds.pixel_array
 
         frame = next(generate_frames(ds))
         params = get_parameters(frame)
-        assert params['is_signed'] == False
+        assert params["is_signed"] is False
 
-        #self.plot(arr)
+        # self.plot(arr)
 
     def test_data_signed_pr_0(self):
         """Test signed JPEG data with Pixel Representation 0"""
-        ds = self.ds['TOSHIBA_J2K_SIZ1_PixRep0.dcm']['ds']
+        ds = self.ds["TOSHIBA_J2K_SIZ1_PixRep0.dcm"]["ds"]
         assert self.uid == ds.file_meta.TransferSyntaxUID
         assert 1 == ds.SamplesPerPixel
-        assert 1 == getattr(ds, 'NumberOfFrames', 1)
-        assert 'MONOCHROME' in ds.PhotometricInterpretation
+        assert 1 == getattr(ds, "NumberOfFrames", 1)
+        assert "MONOCHROME" in ds.PhotometricInterpretation
         assert 16 == ds.BitsAllocated
         assert 16 == ds.BitsStored
         assert 0 == ds.PixelRepresentation
@@ -688,13 +688,11 @@ class TestJPEG2000Lossless(HandlerTestBase):
             r"'signed'"
         )
         with pytest.warns(UserWarning, match=msg):
-            arr = ds.pixel_array
+            ds.pixel_array
 
         frame = next(generate_frames(ds))
         params = get_parameters(frame)
-        assert params['is_signed'] == True
-
-        #self.plot(arr)
+        assert params["is_signed"] is True
 
 
 @pytest.mark.skipif(not HAS_PYDICOM, reason="No dependencies")
@@ -703,73 +701,74 @@ class TestJPEG2000(HandlerTestBase):
 
     1.2.840.10008.1.2.4.91 : JPEG 2000 Image Compression
     """
-    uid = '1.2.840.10008.1.2.4.91'
+
+    uid = "1.2.840.10008.1.2.4.91"
 
     @pytest.mark.skip("No suitable dataset")
     def test_1s_1f_i_08_08(self):
         """Test 1 component, 1 frame, signed 8-bit."""
-        ds = self.ds['.dcm']['ds']
+        ds = self.ds[".dcm"]["ds"]
         assert self.uid == ds.file_meta.TransferSyntaxUID
         assert 1 == ds.SamplesPerPixel
-        assert 1 == getattr(ds, 'NumberOfFrames', 1)
-        assert 'MONOCHROME' in ds.PhotometricInterpretation
+        assert 1 == getattr(ds, "NumberOfFrames", 1)
+        assert "MONOCHROME" in ds.PhotometricInterpretation
         assert 8 == ds.BitsAllocated
         assert 8 == ds.BitsStored
         assert 1 == ds.PixelRepresentation
 
         arr = ds.pixel_array
         assert arr.flags.writeable
-        assert 'int8' == arr.dtype
+        assert "int8" == arr.dtype
         assert (ds.Rows, ds.Columns) == arr.shape
 
     @pytest.mark.skip("No suitable dataset")
     def test_1s_1f_u_08_08(self):
         """Test 1 component, 1 frame, unsigned 8-bit."""
-        ds = self.ds['.dcm']['ds']
+        ds = self.ds[".dcm"]["ds"]
         assert self.uid == ds.file_meta.TransferSyntaxUID
         assert 1 == ds.SamplesPerPixel
-        assert 1 == getattr(ds, 'NumberOfFrames', 1)
-        assert 'MONOCHROME' in ds.PhotometricInterpretation
+        assert 1 == getattr(ds, "NumberOfFrames", 1)
+        assert "MONOCHROME" in ds.PhotometricInterpretation
         assert 8 == ds.BitsAllocated
         assert 8 == ds.BitsStored
         assert 0 == ds.PixelRepresentation
 
         arr = ds.pixel_array
         assert arr.flags.writeable
-        assert 'int8' == arr.dtype
+        assert "int8" == arr.dtype
         assert (ds.Rows, ds.Columns) == arr.shape
 
     @pytest.mark.skip("No suitable dataset")
     def test_1s_2f_i_08_08(self):
         """Test 1 component, 2 frame, signed 8-bit."""
-        ds = self.ds['.dcm']['ds']
+        ds = self.ds[".dcm"]["ds"]
         assert self.uid == ds.file_meta.TransferSyntaxUID
         assert 1 == ds.SamplesPerPixel
-        assert 2 == getattr(ds, 'NumberOfFrames', 1)
-        assert 'MONOCHROME' in ds.PhotometricInterpretation
+        assert 2 == getattr(ds, "NumberOfFrames", 1)
+        assert "MONOCHROME" in ds.PhotometricInterpretation
         assert 8 == ds.BitsAllocated
         assert 8 == ds.BitsStored
         assert 1 == ds.PixelRepresentation
 
         arr = ds.pixel_array
         assert arr.flags.writeable
-        assert 'int8' == arr.dtype
+        assert "int8" == arr.dtype
         assert (ds.Rows, ds.Columns) == arr.shape
 
     def test_3s_1f_u_08_08(self):
         """Test 3 component, 1 frame, unsigned 8-bit."""
-        ds = self.ds['SC_rgb_gdcm_KY.dcm']['ds']
+        ds = self.ds["SC_rgb_gdcm_KY.dcm"]["ds"]
         assert self.uid == ds.file_meta.TransferSyntaxUID
         assert 3 == ds.SamplesPerPixel
-        assert 1 == getattr(ds, 'NumberOfFrames', 1)
-        assert 'RGB' in ds.PhotometricInterpretation
+        assert 1 == getattr(ds, "NumberOfFrames", 1)
+        assert "RGB" in ds.PhotometricInterpretation
         assert 8 == ds.BitsAllocated
         assert 8 == ds.BitsStored
         assert 0 == ds.PixelRepresentation
 
         arr = ds.pixel_array
         assert arr.flags.writeable
-        assert 'uint8' == arr.dtype
+        assert "uint8" == arr.dtype
         assert (ds.Rows, ds.Columns, ds.SamplesPerPixel) == arr.shape
 
         assert [255, 0, 0] == arr[5, 0].tolist()
@@ -786,44 +785,44 @@ class TestJPEG2000(HandlerTestBase):
     @pytest.mark.skip("No suitable dataset")
     def test_3s_2f_i_08_08(self):
         """Test 3 component, 2 frame, signed 8-bit."""
-        ds = self.ds['.dcm']['ds']
+        ds = self.ds[".dcm"]["ds"]
         assert self.uid == ds.file_meta.TransferSyntaxUID
         assert 1 == ds.SamplesPerPixel
-        assert 1 == getattr(ds, 'NumberOfFrames', 1)
-        assert 'RGB' in ds.PhotometricInterpretation
+        assert 1 == getattr(ds, "NumberOfFrames", 1)
+        assert "RGB" in ds.PhotometricInterpretation
         assert 8 == ds.BitsAllocated
         assert 8 == ds.BitsStored
         assert 1 == ds.PixelRepresentation
 
         arr = ds.pixel_array
         assert arr.flags.writeable
-        assert 'uint8' == arr.dtype
+        assert "uint8" == arr.dtype
         assert (ds.Rows, ds.Columns, ds.SamplesPerPixel) == arr.shape
 
     @pytest.mark.skip("No suitable dataset")
     def test_1s_1f_i_16_14(self):
         """Test 1 component, 1 frame, signed 16/14-bit."""
-        ds = self.ds['693_J2KR.dcm']['ds']
+        ds = self.ds["693_J2KR.dcm"]["ds"]
         assert self.uid == ds.file_meta.TransferSyntaxUID
         assert 1 == ds.SamplesPerPixel
-        assert 1 == getattr(ds, 'NumberOfFrames', 1)
-        assert 'MONOCHROME' in ds.PhotometricInterpretation
+        assert 1 == getattr(ds, "NumberOfFrames", 1)
+        assert "MONOCHROME" in ds.PhotometricInterpretation
         assert 16 == ds.BitsAllocated
         # assert 14 == ds.BitsStored   # wrong bits stored value - should warn?
         assert 1 == ds.PixelRepresentation
 
         arr = ds.pixel_array
         assert arr.flags.writeable
-        assert 'int16' == arr.dtype
+        assert "int16" == arr.dtype
         assert (ds.Rows, ds.Columns) == arr.shape
 
     def test_1s_1f_i_16_16(self):
         """Test 1 component, 1 frame, signed 16/16-bit."""
-        ds = self.ds['693_J2KI.dcm']['ds']
+        ds = self.ds["693_J2KI.dcm"]["ds"]
         assert self.uid == ds.file_meta.TransferSyntaxUID
         assert 1 == ds.SamplesPerPixel
-        assert 1 == getattr(ds, 'NumberOfFrames', 1)
-        assert 'MONOCHROME' in ds.PhotometricInterpretation
+        assert 1 == getattr(ds, "NumberOfFrames", 1)
+        assert "MONOCHROME" in ds.PhotometricInterpretation
         assert 16 == ds.BitsAllocated
         assert 14 == ds.BitsStored  # wrong bits stored
         assert 1 == ds.PixelRepresentation
@@ -835,67 +834,62 @@ class TestJPEG2000(HandlerTestBase):
         with pytest.warns(UserWarning, match=msg):
             arr = ds.pixel_array
         assert arr.flags.writeable
-        assert 'int16' == arr.dtype
+        assert "int16" == arr.dtype
         assert (ds.Rows, ds.Columns) == arr.shape
 
         # Values checked against GDCM
-        assert (
-            [ 812,  894, 1179, 1465, 1751, 2037, 1939, 1841, 1743, 1645] ==
-            arr[290, 135:145].tolist()
-        )
+        assert [812, 894, 1179, 1465, 1751, 2037, 1939, 1841, 1743, 1645] == arr[
+            290, 135:145
+        ].tolist()
         assert -2016 == arr[0, 0]
 
     def test_1s_1f_u_16_12(self):
         """Test 1 component, 1 frame, unsigned 16/12-bit."""
-        ds = self.ds['MR2_J2KI.dcm']['ds']
+        ds = self.ds["MR2_J2KI.dcm"]["ds"]
         assert self.uid == ds.file_meta.TransferSyntaxUID
         assert 1 == ds.SamplesPerPixel
-        assert 1 == getattr(ds, 'NumberOfFrames', 1)
-        assert 'MONOCHROME' in ds.PhotometricInterpretation
+        assert 1 == getattr(ds, "NumberOfFrames", 1)
+        assert "MONOCHROME" in ds.PhotometricInterpretation
         assert 16 == ds.BitsAllocated
         assert 12 == ds.BitsStored
         assert 0 == ds.PixelRepresentation
 
         arr = ds.pixel_array
         assert arr.flags.writeable
-        assert 'uint16' == arr.dtype
+        assert "uint16" == arr.dtype
         assert (ds.Rows, ds.Columns) == arr.shape
 
         # Values checked against GDCM
-        assert (
-            [27, 31, 32, 25, 17,  7,  6, 36, 63, 39] ==
-            arr[770:780, 136].tolist()
-        )
+        assert [27, 31, 32, 25, 17, 7, 6, 36, 63, 39] == arr[770:780, 136].tolist()
 
     def test_1s_1f_u_16_15(self):
         """Test 1 component, 1 frame, unsigned 16/15-bit."""
-        ds = self.ds['RG1_J2KI.dcm']['ds']
+        ds = self.ds["RG1_J2KI.dcm"]["ds"]
         assert self.uid == ds.file_meta.TransferSyntaxUID
         assert 1 == ds.SamplesPerPixel
-        assert 1 == getattr(ds, 'NumberOfFrames', 1)
-        assert 'MONOCHROME' in ds.PhotometricInterpretation
+        assert 1 == getattr(ds, "NumberOfFrames", 1)
+        assert "MONOCHROME" in ds.PhotometricInterpretation
         assert 16 == ds.BitsAllocated
         assert 15 == ds.BitsStored
         assert 0 == ds.PixelRepresentation
 
         arr = ds.pixel_array
         assert arr.flags.writeable
-        assert 'uint16' == arr.dtype
+        assert "uint16" == arr.dtype
         assert (ds.Rows, ds.Columns) == arr.shape
 
         # Values checked against GDCM
-        assert (
-            [24291, 24345, 24401, 24455, 24508, 24559, 24604, 24647, 24687] ==
-            arr[175:184, 28].tolist()
-        )
+        assert [24291, 24345, 24401, 24455, 24508, 24559, 24604, 24647, 24687] == arr[
+            175:184, 28
+        ].tolist()
 
     def test_1s_1f_u_16_16(self):
         """Test 1 component, 1 frame, unsigned 16/16-bit."""
-        ds = self.ds['OsirixFake16BitsStoredFakeSpacing.dcm']['ds']
+        ds = self.ds["OsirixFake16BitsStoredFakeSpacing.dcm"]["ds"]
         assert self.uid == ds.file_meta.TransferSyntaxUID
         assert 1 == ds.SamplesPerPixel
-        assert 1 == getattr(ds, 'NumberOfFrames', 1)
-        assert 'MONOCHROME' in ds.PhotometricInterpretation
+        assert 1 == getattr(ds, "NumberOfFrames", 1)
+        assert "MONOCHROME" in ds.PhotometricInterpretation
         assert 16 == ds.BitsAllocated
         assert 16 == ds.BitsStored
         assert 0 == ds.PixelRepresentation
@@ -907,40 +901,39 @@ class TestJPEG2000(HandlerTestBase):
         with pytest.warns(UserWarning, match=msg):
             arr = ds.pixel_array
         assert arr.flags.writeable
-        assert 'uint16' == arr.dtype
+        assert "uint16" == arr.dtype
         assert (ds.Rows, ds.Columns) == arr.shape
 
         # Values checked against GDCM
-        assert (
-            [1090, 1114, 1135, 1123, 1100, 1100, 1086, 1093, 1128, 1141] ==
-            arr[107, 66:76].tolist()
-        )
+        assert [1090, 1114, 1135, 1123, 1100, 1100, 1086, 1093, 1128, 1141] == arr[
+            107, 66:76
+        ].tolist()
 
     @pytest.mark.skip("No suitable dataset")
     def test_1s_10f_u_16_16(self):
         """Test 1 component, 10 frame, unsigned 16/16-bit."""
-        ds = self.ds['emri_small_jpeg_2k_lossless.dcm']['ds']
+        ds = self.ds["emri_small_jpeg_2k_lossless.dcm"]["ds"]
         assert self.uid == ds.file_meta.TransferSyntaxUID
         assert 1 == ds.SamplesPerPixel
-        assert 10 == getattr(ds, 'NumberOfFrames', 1)
-        assert 'MONOCHROME' in ds.PhotometricInterpretation
+        assert 10 == getattr(ds, "NumberOfFrames", 1)
+        assert "MONOCHROME" in ds.PhotometricInterpretation
         assert 16 == ds.BitsAllocated
         # assert 16 == ds.BitsStored  # wrong bits stored value - should warn?
         assert 0 == ds.PixelRepresentation
 
         arr = ds.pixel_array
         assert arr.flags.writeable
-        assert 'uint16' == arr.dtype
+        assert "uint16" == arr.dtype
         assert (ds.NumberOfFrames, ds.Rows, ds.Columns) == arr.shape
 
     @pytest.mark.skip("No suitable dataset")
     def test_1s_2f_i_16_16(self):
         """Test 1 component, 2 frame, signed 16/16-bit."""
-        ds = self.ds['.dcm']['ds']
+        ds = self.ds[".dcm"]["ds"]
         assert self.uid == ds.file_meta.TransferSyntaxUID
         assert 1 == ds.SamplesPerPixel
-        assert 1 == getattr(ds, 'NumberOfFrames', 1)
-        assert 'MONOCHROME' in ds.PhotometricInterpretation
+        assert 1 == getattr(ds, "NumberOfFrames", 1)
+        assert "MONOCHROME" in ds.PhotometricInterpretation
         assert 16 == ds.BitsAllocated
         assert 16 == ds.BitsStored
         assert 1 == ds.PixelRepresentation
@@ -948,11 +941,11 @@ class TestJPEG2000(HandlerTestBase):
     @pytest.mark.skip("No suitable dataset")
     def test_3s_1f_i_16_16(self):
         """Test 3 component, 1 frame, signed 16/16-bit."""
-        ds = self.ds['.dcm']['ds']
+        ds = self.ds[".dcm"]["ds"]
         assert self.uid == ds.file_meta.TransferSyntaxUID
         assert 1 == ds.SamplesPerPixel
-        assert 1 == getattr(ds, 'NumberOfFrames', 1)
-        assert 'MONOCHROME' in ds.PhotometricInterpretation
+        assert 1 == getattr(ds, "NumberOfFrames", 1)
+        assert "MONOCHROME" in ds.PhotometricInterpretation
         assert 16 == ds.BitsAllocated
         assert 16 == ds.BitsStored
         assert 1 == ds.PixelRepresentation
@@ -960,22 +953,22 @@ class TestJPEG2000(HandlerTestBase):
     @pytest.mark.skip("No suitable dataset")
     def test_3s_2f_i_16_16(self):
         """Test 3 component, 2 frame, signed 16/16-bit."""
-        ds = self.ds['.dcm']['ds']
+        ds = self.ds[".dcm"]["ds"]
         assert self.uid == ds.file_meta.TransferSyntaxUID
         assert 1 == ds.SamplesPerPixel
-        assert 1 == getattr(ds, 'NumberOfFrames', 1)
-        assert 'MONOCHROME' in ds.PhotometricInterpretation
+        assert 1 == getattr(ds, "NumberOfFrames", 1)
+        assert "MONOCHROME" in ds.PhotometricInterpretation
         assert 16 == ds.BitsAllocated
         assert 16 == ds.BitsStored
         assert 1 == ds.PixelRepresentation
 
     def test_jp2(self):
         """Test decoding a non-conformant Pixel Data with JP2 data."""
-        ds = self.ds['MAROTECH_CT_JP2Lossy.dcm']['ds']
+        ds = self.ds["MAROTECH_CT_JP2Lossy.dcm"]["ds"]
         assert self.uid == ds.file_meta.TransferSyntaxUID
         assert 1 == ds.SamplesPerPixel
-        assert 1 == getattr(ds, 'NumberOfFrames', 1)
-        assert 'MONOCHROME' in ds.PhotometricInterpretation
+        assert 1 == getattr(ds, "NumberOfFrames", 1)
+        assert "MONOCHROME" in ds.PhotometricInterpretation
         assert 16 == ds.BitsAllocated
         assert 12 == ds.BitsStored
         assert 0 == ds.PixelRepresentation
@@ -987,11 +980,10 @@ class TestJPEG2000(HandlerTestBase):
         with pytest.warns(UserWarning, match=msg):
             arr = ds.pixel_array
         assert arr.flags.writeable
-        assert 'uint16' == arr.dtype
+        assert "uint16" == arr.dtype
         assert (ds.Rows, ds.Columns) == arr.shape
 
         # Values checked against GDCM
-        assert (
-            [ 939,  698,  988, 1074, 1029, 1218, 1471,  873,  647,  864] ==
-            arr[191, 136:146].tolist()
-        )
+        assert [939, 698, 988, 1074, 1029, 1218, 1471, 873, 647, 864] == arr[
+            191, 136:146
+        ].tolist()

--- a/openjpeg/tests/test_parameters.py
+++ b/openjpeg/tests/test_parameters.py
@@ -1,13 +1,10 @@
 """Tests for get_parameters()."""
 
-from io import BytesIO
-import os
 import pytest
-
-import numpy as np
 
 try:
     from pydicom.encaps import generate_pixel_data_frame
+
     HAS_PYDICOM = True
 except ImportError:
     HAS_PYDICOM = False
@@ -16,46 +13,46 @@ from openjpeg import get_parameters
 from openjpeg.data import get_indexed_datasets, JPEG_DIRECTORY
 
 
-DIR_15444 = JPEG_DIRECTORY / '15444'
+DIR_15444 = JPEG_DIRECTORY / "15444"
 
 
 REF_DCM = {
-    '1.2.840.10008.1.2.4.90' : [
+    "1.2.840.10008.1.2.4.90": [
         # filename, (rows, columns, samples/px, bits/sample, signed?)
-        ('693_J2KR.dcm', (512, 512, 1, 14, True)),
-        ('966_fixed.dcm', (2128, 2000, 1, 12, False)),
-        ('emri_small_jpeg_2k_lossless.dcm', (64, 64, 1, 16, False)),
-        ('explicit_VR-UN.dcm', (512, 512, 1, 16, True)),
-        ('GDCMJ2K_TextGBR.dcm', (400, 400, 3, 8, False)),
-        ('JPEG2KLossless_1s_1f_u_16_16.dcm', (1416, 1420, 1, 16, False)),
-        ('MR_small_jp2klossless.dcm', (64, 64, 1, 16, True)),
-        ('MR2_J2KR.dcm', (1024, 1024, 1, 12, False)),
-        ('NM_Kakadu44_SOTmarkerincons.dcm', (2500, 2048, 1, 16, False)),
-        ('RG1_J2KR.dcm', (1955, 1841, 1, 15, False)),
-        ('RG3_J2KR.dcm', (1760, 1760, 1, 10, False)),
-        ('TOSHIBA_J2K_OpenJPEGv2Regression.dcm', (512, 512, 1, 16, False)),
-        ('TOSHIBA_J2K_SIZ0_PixRep1.dcm', (512, 512, 1, 16, False)),
-        ('TOSHIBA_J2K_SIZ1_PixRep0.dcm', (512, 512, 1, 16, True)),
-        ('US1_J2KR.dcm', (480, 640, 3, 8, False)),
+        ("693_J2KR.dcm", (512, 512, 1, 14, True)),
+        ("966_fixed.dcm", (2128, 2000, 1, 12, False)),
+        ("emri_small_jpeg_2k_lossless.dcm", (64, 64, 1, 16, False)),
+        ("explicit_VR-UN.dcm", (512, 512, 1, 16, True)),
+        ("GDCMJ2K_TextGBR.dcm", (400, 400, 3, 8, False)),
+        ("JPEG2KLossless_1s_1f_u_16_16.dcm", (1416, 1420, 1, 16, False)),
+        ("MR_small_jp2klossless.dcm", (64, 64, 1, 16, True)),
+        ("MR2_J2KR.dcm", (1024, 1024, 1, 12, False)),
+        ("NM_Kakadu44_SOTmarkerincons.dcm", (2500, 2048, 1, 16, False)),
+        ("RG1_J2KR.dcm", (1955, 1841, 1, 15, False)),
+        ("RG3_J2KR.dcm", (1760, 1760, 1, 10, False)),
+        ("TOSHIBA_J2K_OpenJPEGv2Regression.dcm", (512, 512, 1, 16, False)),
+        ("TOSHIBA_J2K_SIZ0_PixRep1.dcm", (512, 512, 1, 16, False)),
+        ("TOSHIBA_J2K_SIZ1_PixRep0.dcm", (512, 512, 1, 16, True)),
+        ("US1_J2KR.dcm", (480, 640, 3, 8, False)),
     ],
-    '1.2.840.10008.1.2.4.91' : [
-        ('693_J2KI.dcm', (512, 512, 1, 16, True)),
-        ('ELSCINT1_JP2vsJ2K.dcm', (512, 512, 1, 12, False)),
-        ('JPEG2000.dcm', (1024, 256, 1, 16, True)),
-        ('MAROTECH_CT_JP2Lossy.dcm', (716, 512, 1, 12, False)),
-        ('MR2_J2KI.dcm', (1024, 1024, 1, 12, False)),
-        ('OsirixFake16BitsStoredFakeSpacing.dcm', (224, 176, 1, 11, False)),
-        ('RG1_J2KI.dcm', (1955, 1841, 1, 15, False)),
-        ('RG3_J2KI.dcm', (1760, 1760, 1, 10, False)),
-        ('SC_rgb_gdcm_KY.dcm', (100, 100, 3, 8, False)),
-        ('US1_J2KI.dcm', (480, 640, 3, 8, False)),
+    "1.2.840.10008.1.2.4.91": [
+        ("693_J2KI.dcm", (512, 512, 1, 16, True)),
+        ("ELSCINT1_JP2vsJ2K.dcm", (512, 512, 1, 12, False)),
+        ("JPEG2000.dcm", (1024, 256, 1, 16, True)),
+        ("MAROTECH_CT_JP2Lossy.dcm", (716, 512, 1, 12, False)),
+        ("MR2_J2KI.dcm", (1024, 1024, 1, 12, False)),
+        ("OsirixFake16BitsStoredFakeSpacing.dcm", (224, 176, 1, 11, False)),
+        ("RG1_J2KI.dcm", (1955, 1841, 1, 15, False)),
+        ("RG3_J2KI.dcm", (1760, 1760, 1, 10, False)),
+        ("SC_rgb_gdcm_KY.dcm", (100, 100, 3, 8, False)),
+        ("US1_J2KI.dcm", (480, 640, 3, 8, False)),
     ],
 }
 
 
 def generate_frames(ds):
     """Return a frame generator for DICOM datasets."""
-    nr_frames = ds.get('NumberOfFrames', 1)
+    nr_frames = ds.get("NumberOfFrames", 1)
     return generate_pixel_data_frame(ds.PixelData, nr_frames)
 
 
@@ -83,41 +80,42 @@ def test_subsampling():
 @pytest.mark.skipif(not HAS_PYDICOM, reason="No pydicom")
 class TestGetParametersDCM:
     """Tests for get_parameters() using DICOM datasets."""
-    @pytest.mark.parametrize("fname, info", REF_DCM['1.2.840.10008.1.2.4.90'])
+
+    @pytest.mark.parametrize("fname, info", REF_DCM["1.2.840.10008.1.2.4.90"])
     def test_jpeg2000r(self, fname, info):
         """Test get_parameters() for the baseline datasets."""
-        index = get_indexed_datasets('1.2.840.10008.1.2.4.90')
-        ds = index[fname]['ds']
+        index = get_indexed_datasets("1.2.840.10008.1.2.4.90")
+        ds = index[fname]["ds"]
 
         frame = next(generate_frames(ds))
         params = get_parameters(frame)
 
-        assert (info[0], info[1]) == (params['rows'], params['columns'])
-        assert info[2] == params['nr_components']
-        assert info[3] == params['precision']
-        assert info[4] == params['is_signed']
+        assert (info[0], info[1]) == (params["rows"], params["columns"])
+        assert info[2] == params["nr_components"]
+        assert info[3] == params["precision"]
+        assert info[4] == params["is_signed"]
 
-    @pytest.mark.parametrize("fname, info", REF_DCM['1.2.840.10008.1.2.4.91'])
+    @pytest.mark.parametrize("fname, info", REF_DCM["1.2.840.10008.1.2.4.91"])
     def test_jpeg2000i(self, fname, info):
         """Test get_parameters() for the baseline datasets."""
-        index = get_indexed_datasets('1.2.840.10008.1.2.4.91')
-        ds = index[fname]['ds']
+        index = get_indexed_datasets("1.2.840.10008.1.2.4.91")
+        ds = index[fname]["ds"]
 
         frame = next(generate_frames(ds))
         params = get_parameters(frame)
 
-        assert (info[0], info[1]) == (params['rows'], params['columns'])
-        assert info[2] == params['nr_components']
-        assert info[3] == params['precision']
-        assert info[4] == params['is_signed']
+        assert (info[0], info[1]) == (params["rows"], params["columns"])
+        assert info[2] == params["nr_components"]
+        assert info[3] == params["precision"]
+        assert info[4] == params["is_signed"]
 
     @pytest.mark.skipif(not HAS_PYDICOM, reason="No pydicom")
     def test_decode_bad_type_raises(self):
         """Test decoding using invalid type raises."""
-        index = get_indexed_datasets('1.2.840.10008.1.2.4.90')
-        ds = index['MR_small_jp2klossless.dcm']['ds']
+        index = get_indexed_datasets("1.2.840.10008.1.2.4.90")
+        ds = index["MR_small_jp2klossless.dcm"]["ds"]
         frame = tuple(next(generate_frames(ds)))
-        assert not hasattr(frame, 'tell') and not isinstance(frame, bytes)
+        assert not hasattr(frame, "tell") and not isinstance(frame, bytes)
 
         msg = (
             r"The Python object containing the encoded JPEG 2000 data must "
@@ -129,8 +127,8 @@ class TestGetParametersDCM:
     @pytest.mark.skipif(not HAS_PYDICOM, reason="No pydicom")
     def test_decode_format_raises(self):
         """Test decoding using invalid format raises."""
-        index = get_indexed_datasets('1.2.840.10008.1.2.4.90')
-        ds = index['693_J2KR.dcm']['ds']
+        index = get_indexed_datasets("1.2.840.10008.1.2.4.90")
+        ds = index["693_J2KR.dcm"]["ds"]
         frame = next(generate_frames(ds))
         msg = r"Unsupported 'j2k_format' value: 3"
         with pytest.raises(ValueError, match=msg):

--- a/openjpeg/utils.py
+++ b/openjpeg/utils.py
@@ -1,4 +1,3 @@
-
 from enum import IntEnum
 from io import BytesIO
 from math import ceil
@@ -115,7 +114,7 @@ def decode(
         If the decoding failed.
     """
     if isinstance(stream, (str, Path)):
-        with open(stream, 'rb') as f:
+        with open(stream, "rb") as f:
             buffer: BinaryIO = BytesIO(f.read())
             buffer.seek(0)
     elif isinstance(stream, (bytes, bytearray)):
@@ -152,7 +151,7 @@ def decode(
     arr = arr.view(dtype)
 
     shape = [rows, columns]
-    if pixels_per_sample> 1:
+    if pixels_per_sample > 1:
         shape.append(pixels_per_sample)
 
     return arr.reshape(*shape)
@@ -162,7 +161,7 @@ def decode_pixel_data(
     src: bytes,
     ds: Union["Dataset", Dict[str, Any], None] = None,
     version: int = Version.v1,
-    **kwargs: Any
+    **kwargs: Any,
 ) -> Union[np.ndarray, bytearray]:
     """Return the decoded JPEG 2000 data as a :class:`numpy.ndarray`.
 
@@ -212,14 +211,12 @@ def decode_pixel_data(
         samples_per_pixel = kwargs.get("samples_per_pixel")
         bits_stored = kwargs.get("bits_stored")
         pixel_representation = kwargs.get("pixel_representation")
-        no_kwargs = None in (
-            samples_per_pixel, bits_stored, pixel_representation
-        )
+        no_kwargs = None in (samples_per_pixel, bits_stored, pixel_representation)
 
         if not ds and no_kwargs:
             return cast(np.ndarray, arr)
 
-
+        ds = cast("Dataset", ds)
         samples_per_pixel = ds.get("SamplesPerPixel", samples_per_pixel)
         bits_stored = ds.get("BitsStored", bits_stored)
         pixel_representation = ds.get("PixelRepresentation", pixel_representation)
@@ -229,7 +226,7 @@ def decode_pixel_data(
             warnings.warn(
                 f"The (0028,0002) Samples per Pixel value '{samples_per_pixel}' "
                 f"in the dataset does not match the number of components "
-                f"\'{meta['nr_components']}\' found in the JPEG 2000 data. "
+                f"'{meta['nr_components']}' found in the JPEG 2000 data. "
                 f"It's recommended that you change the  Samples per Pixel value "
                 f"to produce the correct output"
             )
@@ -238,7 +235,7 @@ def decode_pixel_data(
             warnings.warn(
                 f"The (0028,0101) Bits Stored value '{bits_stored}' in the "
                 f"dataset does not match the component precision value "
-                f"\'{meta['precision']}\' found in the JPEG 2000 data. "
+                f"'{meta['precision']}' found in the JPEG 2000 data. "
                 f"It's recommended that you change the Bits Stored value to "
                 f"produce the correct output"
             )
@@ -297,7 +294,7 @@ def get_parameters(
         If reading the image parameters failed.
     """
     if isinstance(stream, (str, Path)):
-        with open(stream, 'rb') as f:
+        with open(stream, "rb") as f:
             buffer: BinaryIO = BytesIO(f.read())
             buffer.seek(0)
     elif isinstance(stream, (bytes, bytearray)):

--- a/openjpeg/utils.py
+++ b/openjpeg/utils.py
@@ -21,6 +21,16 @@ class Version(IntEnum):
     v2 = 2
 
 
+MAGIC_NUMBERS = {
+    # JPEG 2000 codestream, has no header, .j2k, .jpc, .j2c
+    b"\xff\x4f\xff\x51": 0,
+    # JP2 and JP2 RFC3745, .jp2
+    b"\x0d\x0a\x87\x0a": 2,
+    b"\x00\x00\x00\x0c\x6a\x50\x20\x20\x0d\x0a\x87\x0a": 2,
+    # JPT, .jpt - shrug
+}
+
+
 def _get_format(stream: BinaryIO) -> int:
     """Return the JPEG 2000 format for the encoded data in `stream`.
 
@@ -46,24 +56,14 @@ def _get_format(stream: BinaryIO) -> int:
     """
     data = stream.read(20)
     stream.seek(0)
-    #print(" ".join([f"{ii:02X}" for ii in data[:12]]))
-
-    magic_numbers = {
-        # JPEG 2000 codestream, has no header, .j2k, .jpc, .j2c
-        b"\xff\x4f\xff\x51": 0,
-        # JP2 and JP2 RFC3745, .jp2
-        b"\x0d\x0a\x87\x0a": 2,
-        b"\x00\x00\x00\x0c\x6a\x50\x20\x20\x0d\x0a\x87\x0a": 2,
-        # JPT, .jpt - shrug
-    }
 
     try:
-        return magic_numbers[data[:4]]
+        return MAGIC_NUMBERS[data[:4]]
     except KeyError:
         pass
 
     try:
-        return magic_numbers[data[:12]]
+        return MAGIC_NUMBERS[data[:12]]
     except KeyError:
         pass
 


### PR DESCRIPTION
Just a note that the tests fail because the current release of pylibjpeg uses distutils to import the plugins, which has been removed in Python 3.12. 