### PR TITLE
Fix using MCT with RGB, update type hints

### DIFF
--- a/openjpeg/tests/test_encode.py
+++ b/openjpeg/tests/test_encode.py
@@ -1713,7 +1713,7 @@ class TestEncodePixelData:
             "pixel_representation": 0,
             "bits_stored": 8,
         }
-        for pi in ("RGB", "YBR_ICT", "YBR_RCT"):
+        for pi in ("YBR_ICT", "YBR_RCT"):
             buffer = encode_pixel_data(
                 arr.tobytes(),
                 photometric_interpretation=pi,
@@ -1722,14 +1722,15 @@ class TestEncodePixelData:
             param = parse_j2k(buffer)
             assert param["mct"] is True
 
-        buffer = encode_pixel_data(
-            arr.tobytes(),
-            photometric_interpretation="YBR_FULL",
-            use_mct=True,
-            **kwargs,
-        )
-        param = parse_j2k(buffer)
-        assert param["mct"] is False
+        for pi in ("RGB", "YBR_FULL", "MONOCHROME1"):
+            buffer = encode_pixel_data(
+                arr.tobytes(),
+                photometric_interpretation=pi,
+                use_mct=True,
+                **kwargs,
+            )
+            param = parse_j2k(buffer)
+            assert param["mct"] is False
 
     def test_codec_format_ignored(self):
         """Test that codec_format gets ignored."""

--- a/openjpeg/utils.py
+++ b/openjpeg/utils.py
@@ -567,7 +567,7 @@ encode = encode_array
 
 
 def encode_buffer(
-    src: Union[bytes, bytearray],
+    src: bytes,
     columns: int,
     rows: int,
     samples_per_pixel: int,
@@ -609,7 +609,7 @@ def encode_buffer(
 
     Parameters
     ----------
-    src : bytes | bytearray
+    src : bytes
         A single frame of little endian, colour-by-pixel ordered image data to
         be JPEG 2000 encoded. Each pixel should be encoded using the following
         (each pixel has 1 or more samples):
@@ -712,16 +712,14 @@ def encode_buffer(
     return cast(bytes, buffer)
 
 
-def encode_pixel_data(
-    src: Union[bytes, bytearray], **kwargs: Any
-) -> bytes:
+def encode_pixel_data(src: bytes, **kwargs: Any) -> bytes:
     """Return the JPEG 2000 compressed `src`.
 
     .. versionadded:: 2.2
 
     Parameters
     ----------
-    src : bytes | bytearray
+    src : bytes
         A single frame of little endian, colour-by-pixel ordered image data to
         be JPEG2000 encoded. Each pixel should be encoded using the following:
 
@@ -743,7 +741,7 @@ def encode_pixel_data(
 
         * ``'use_mct'``: bool: ``True`` to use MCT with RGB images (default)
           ``False`` otherwise. Will be ignored if `photometric_interpretation`
-          is not RGB, YBR_RCT or YBR_ICT.
+          is not YBR_RCT or YBR_ICT.
         * ''`compression_ratios'``: list[float] - required for lossy encoding if
           `signal_noise_ratios` is not used. The desired compression ratio to
           use for each quality layer.
@@ -759,7 +757,7 @@ def encode_pixel_data(
     # A J2K codestream doesn't track the colour space, so the photometric
     #   interpretation is only used to help with setting MCT
     pi = kwargs["photometric_interpretation"]
-    if pi in ("RGB", "YBR_ICT", "YBR_RCT"):
+    if pi in ("YBR_ICT", "YBR_RCT"):
         kwargs["photometric_interpretation"] = 1
     else:
         kwargs["photometric_interpretation"] = 0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ packages = [
     {include = "openjpeg" },
 ]
 readme = "README.md"
-version = "2.2.0"
+version = "2.2.1"
 
 
 [tool.poetry.dependencies]


### PR DESCRIPTION
* Fixes using MCT with RGB in `encode_pixel_data()`
* Removes `bytearray` as image source in `encode_pixel_data()` and `encode_buffer()`