### PR TITLE
Fix number of layers check

### DIFF
--- a/openjpeg/_openjpeg.pyx
+++ b/openjpeg/_openjpeg.pyx
@@ -304,8 +304,8 @@ def encode_array(
             "Only one of 'compression_ratios' or 'signal_noise_ratios' is "
             "allowed when performing lossy compression"
         )
-    if len(compression_ratios) > 10 or len(signal_noise_ratios) > 10:
-        raise ValueError("More than 10 compression layers is not supported")
+    if len(compression_ratios) > 100 or len(signal_noise_ratios) > 100:
+        raise ValueError("More than 100 compression layers is not supported")
 
     # The destination for the encoded J2K codestream, needs to support BinaryIO
     dst = BytesIO()
@@ -449,8 +449,8 @@ def encode_buffer(
             "Only one of 'compression_ratios' or 'signal_noise_ratios' is "
             "allowed when performing lossy compression"
         )
-    if len(compression_ratios) > 10 or len(signal_noise_ratios) > 10:
-        raise ValueError("More than 10 compression layers is not supported")
+    if len(compression_ratios) > 100 or len(signal_noise_ratios) > 100:
+        raise ValueError("More than 100 compression layers is not supported")
 
     dst = BytesIO()
     return_code = EncodeBuffer(

--- a/openjpeg/tests/test_encode.py
+++ b/openjpeg/tests/test_encode.py
@@ -219,9 +219,9 @@ class TestEncode:
 
     def test_invalid_compression_ratios_raises(self):
         """Test an invalid 'compression_ratios' raises exceptions."""
-        msg = "More than 10 compression layers is not supported"
+        msg = "More than 100 compression layers is not supported"
         with pytest.raises(ValueError, match=msg):
-            encode_array(np.ones((1, 2), dtype="u1"), compression_ratios=[1] * 11)
+            encode_array(np.ones((1, 2), dtype="u1"), compression_ratios=[1] * 101)
 
         msg = (
             "Error encoding the data: invalid compression ratio, lowest value "
@@ -232,9 +232,9 @@ class TestEncode:
 
     def test_invalid_signal_noise_ratios_raises(self):
         """Test an invalid 'signal_noise_ratios' raises exceptions."""
-        msg = "More than 10 compression layers is not supported"
+        msg = "More than 100 compression layers is not supported"
         with pytest.raises(ValueError, match=msg):
-            encode_array(np.ones((1, 2), dtype="u1"), signal_noise_ratios=[1] * 11)
+            encode_array(np.ones((1, 2), dtype="u1"), signal_noise_ratios=[1] * 101)
 
         msg = (
             "Error encoding the data: invalid signal-to-noise ratio, lowest "
@@ -802,9 +802,9 @@ class TestEncodeBuffer:
 
     def test_invalid_compression_ratios_raises(self):
         """Test an invalid 'compression_ratios' raises exceptions."""
-        msg = "More than 10 compression layers is not supported"
+        msg = "More than 100 compression layers is not supported"
         with pytest.raises(ValueError, match=msg):
-            encode_buffer(b"\x00", 1, 1, 1, 8, False, compression_ratios=[1] * 11)
+            encode_buffer(b"\x00", 1, 1, 1, 8, False, compression_ratios=[1] * 101)
 
         msg = (
             "Error encoding the data: invalid compression ratio, lowest value "
@@ -815,9 +815,9 @@ class TestEncodeBuffer:
 
     def test_invalid_signal_noise_ratios_raises(self):
         """Test an invalid 'signal_noise_ratios' raises exceptions."""
-        msg = "More than 10 compression layers is not supported"
+        msg = "More than 100 compression layers is not supported"
         with pytest.raises(ValueError, match=msg):
-            encode_buffer(b"\x00", 1, 1, 1, 8, False, signal_noise_ratios=[1] * 11)
+            encode_buffer(b"\x00", 1, 1, 1, 8, False, signal_noise_ratios=[1] * 101)
 
         msg = (
             "Error encoding the data: invalid signal-to-noise ratio, lowest "


### PR DESCRIPTION
The number of layers supported is later checked as > 100:

https://github.com/bradh/pylibjpeg-openjpeg/blob/590e4316fc9ae373775ea843a7399ce03d05e37a/lib/interface/encode.c#L245

and 

https://github.com/bradh/pylibjpeg-openjpeg/blob/590e4316fc9ae373775ea843a7399ce03d05e37a/lib/interface/encode.c#L274

This makes the wrapper code consistent.

The profile I'm targeting requires 20 layers.