### PR TITLE
add option for 5-3 reversible with multiple layers

### DIFF
--- a/lib/interface/encode.c
+++ b/lib/interface/encode.c
@@ -39,7 +39,8 @@ extern int EncodeArray(
     PyObject *signal_noise_ratios,
     int codec_format,
     int add_tlm,
-    int add_plt
+    int add_plt,
+    int transformation_type
 )
 {
     /* Encode a numpy ndarray using JPEG 2000.
@@ -70,6 +71,10 @@ extern int EncodeArray(
         Add tile-part data length markers (TLM). Supported values 0-1.
     add_plt : int
         Add packet length tile-part header markers (PLT). Supported values 0-1.
+    transformation_type: int
+        Set the transformation type. 0 = 5-3 reversible, 1 = 9-7 irreversible,
+        -1 = automatically determined from the compression_ratios or
+        signal_noise_ratios argument
 
     Returns
     -------
@@ -246,6 +251,7 @@ extern int EncodeArray(
     if (nr_cr_layers > 0 || nr_snr_layers > 0) {
         // Lossy compression using compression ratios
         // For 1 quality layer we use reversible if CR is 1 or PSNR is 0
+        // unless overridden by the caller
         parameters.irreversible = 1;  // use DWT 9-7
         if (nr_cr_layers > 0) {
             if (nr_cr_layers > 100) {
@@ -306,6 +312,10 @@ extern int EncodeArray(
                 "Encoding using lossy compression based on peak signal-to-noise ratios"
             );
         }
+    }
+    if (transformation_type != -1) {
+        // Explicit requirement
+        parameters.irreversible = transformation_type;
     }
 
     py_debug("Input validation complete, setting up for encoding");
@@ -516,7 +526,8 @@ extern int EncodeBuffer(
     PyObject *signal_noise_ratios,
     int codec_format,
     int add_tlm,
-    int add_plt
+    int add_plt,
+    int transformation_type
 )
 {
     /* Encode image data using JPEG 2000.
@@ -544,10 +555,10 @@ extern int EncodeBuffer(
     use_mct : int
         Supported values 0-1, can't be used with subsampling
     compression_ratios : list[float]
-        Encode lossy with the specified compression ratio for each quality
+        Encode with the specified compression ratio for each quality
         layer. The ratio should be decreasing with increasing layer.
     signal_noise_ratios : list[float]
-        Encode lossy with the specified peak signal-to-noise ratio for each
+        Encode  with the specified peak signal-to-noise ratio for each
         quality layer. The ratio should be increasing with increasing layer.
     codec_format : int
         The format of the encoded JPEG 2000 data, one of:
@@ -557,6 +568,10 @@ extern int EncodeBuffer(
         Add tile-part data length markers (TLM). Supported values 0-1.
     add_plt : int
         Add packet length tile-part header markers (PLT). Supported values 0-1.
+    transformation_type: int
+        Set the transformation type. 0 = 5-3 reversible, 1 = 9-7 irreversible,
+        -1 = automatically determined from the compression_ratios or
+        signal_noise_ratios argument
 
     Returns
     -------

--- a/openjpeg/_openjpeg.pyx
+++ b/openjpeg/_openjpeg.pyx
@@ -34,6 +34,7 @@ cdef extern int EncodeArray(
     int codec_format,
     bint add_tlm,
     bint add_plt,
+    int transformation_type,
 )
 cdef extern int EncodeBuffer(
     PyObject* src,
@@ -50,6 +51,7 @@ cdef extern int EncodeBuffer(
     int codec_format,
     bint add_tlm,
     bint add_plt,
+    int transformation_type,
 )
 
 
@@ -219,6 +221,7 @@ def encode_array(
     int codec_format,
     bint add_tlm,
     bint add_plt,
+    int transformation_type,
 ) -> Tuple[int, bytes]:
     """Return the JPEG 2000 compressed `arr`.
 
@@ -249,6 +252,10 @@ def encode_array(
         If ``True`` then add tile-part length markers (TLM) to the codestream.
     add_plt : bool
         If ``True`` then add packet length tile-part header markers (PLT) to the codestream.
+    transformation_type: int
+        transformation type. 0 = 5-3 reversible, 1 = 9-7 irreversible,
+        -1 = automatically determined from the compression_ratios or signal_noise_ratios
+        argument
 
     Returns
     -------
@@ -330,6 +337,7 @@ def encode_array(
         codec_format,
         add_tlm,
         add_plt,
+        transformation_type,
     )
     return return_code, dst.getvalue()
 
@@ -348,6 +356,7 @@ def encode_buffer(
     int codec_format,
     bint add_tlm,
     bint add_plt,
+    int transformation_type,
 
 ) -> Tuple[int, bytes]:
     """Return the JPEG 2000 compressed `src`.
@@ -394,6 +403,10 @@ def encode_buffer(
         If ``True`` then add tile-part length markers (TLM) to the codestream.
     add_plt : bool
         If ``True`` then add packet length tile-part header markers (PLT) to the codestream.
+    transformation_type: int
+        transformation type. 0 = 5-3 reversible, 1 = 9-7 irreversible,
+        -1 = automatically determined from the compression_ratios or signal_noise_ratios
+        argument
 
     Returns
     -------
@@ -471,6 +484,12 @@ def encode_buffer(
     if len(compression_ratios) > 100 or len(signal_noise_ratios) > 100:
         raise ValueError("More than 100 compression layers is not supported")
 
+    if transformation_type not in (-1, 0, 1):
+        raise ValueError(
+            f"Invalid 'transformation_type' value '{transformation_type}', must be 0, 1 "
+            "or -1"
+        )
+
     dst = BytesIO()
     return_code = EncodeBuffer(
         <PyObject *> src,
@@ -487,5 +506,6 @@ def encode_buffer(
         codec_format,
         add_tlm,
         add_plt,
+        transformation_type,
     )
     return return_code, dst.getvalue()

--- a/openjpeg/tests/test_encode.py
+++ b/openjpeg/tests/test_encode.py
@@ -51,10 +51,18 @@ def parse_j2k(buffer):
     # l_cod = buffer[o + 2 : o + 4]
     # s_cod = buffer[o + 4 : o + 5]
     sg_cod = buffer[o + 5 : o + 9]
+    # SPcod has variable length because of precincts. At least 5 bytes though.
+    sp_cod = buffer[o + 9 : o + 14]
 
     # progression_order = sg_cod[0]
     nr_layers = sg_cod[1:3]
     mct = sg_cod[3]  # 0 for none, 1 for applied
+
+    num_decomposition_levels = sp_cod[0]
+    # code_block_width = sp_cod[1]
+    # code_block_height = sp_cod[2]
+    # code_block_style = sp_cod[3]
+    transformation = sp_cod[4]
 
     param = {}
     if ssiz & 0x80:
@@ -67,6 +75,10 @@ def parse_j2k(buffer):
     param["components"] = nr_components
     param["mct"] = bool(mct)
     param["layers"] = unpack(">H", nr_layers)[0]
+    param["decomposition_levels"] = num_decomposition_levels
+    param["transformation"] = (
+        "9-7 Irreversible" if transformation == 0 else "5-3 Reversible"
+    )
 
     return param
 
@@ -411,6 +423,7 @@ class TestEncode:
         assert param["is_signed"] is False
         assert param["layers"] == 1
         assert param["components"] == 1
+        assert param["transformation"] == "5-3 Reversible"
 
         assert out.dtype.kind == "u"
         assert np.array_equal(mono, out)
@@ -426,6 +439,7 @@ class TestEncode:
         assert param["is_signed"] is False
         assert param["layers"] == 1
         assert param["components"] == 3
+        assert param["transformation"] == "5-3 Reversible"
 
         assert out.dtype.kind == "u"
         assert np.array_equal(arr, out)
@@ -445,6 +459,7 @@ class TestEncode:
             assert param["is_signed"] is False
             assert param["layers"] == 1
             assert param["components"] == 1
+            assert param["transformation"] == "5-3 Reversible"
 
             assert out.dtype.kind == "u"
             assert np.array_equal(arr, out)
@@ -459,6 +474,7 @@ class TestEncode:
             assert param["is_signed"] is False
             assert param["layers"] == 1
             assert param["components"] == 3
+            assert param["transformation"] == "5-3 Reversible"
 
             assert out.dtype.kind == "u"
             assert np.array_equal(arr, out)
@@ -473,6 +489,74 @@ class TestEncode:
             assert param["is_signed"] is False
             assert param["layers"] == 1
             assert param["components"] == 4
+            assert param["transformation"] == "5-3 Reversible"
+
+            assert out.dtype.kind == "u"
+            assert np.array_equal(arr, out)
+
+    def test_lossless_unsigned_explicit_layers(self):
+        """Test encoding unsigned data for bit-depth 1-16"""
+        rows = 123
+        cols = 234
+        for bit_depth in range(2, 17):
+            maximum = 2**bit_depth - 1
+            dtype = f"u{math.ceil(bit_depth / 8)}"
+            arr = np.random.randint(0, high=maximum + 1, size=(rows, cols), dtype=dtype)
+            buffer = encode_array(
+                arr,
+                photometric_interpretation=PI.MONOCHROME2,
+                transformation_type=0,
+                compression_ratios=[5, 2, 1],
+            )
+            out = decode(buffer)
+            param = parse_j2k(buffer)
+            assert param["precision"] == bit_depth
+            assert param["is_signed"] is False
+            assert param["layers"] == 3
+            assert param["components"] == 1
+            assert param["transformation"] == "5-3 Reversible"
+
+            assert out.dtype.kind == "u"
+            assert np.array_equal(arr, out)
+
+            arr = np.random.randint(
+                0, high=maximum + 1, size=(rows, cols, 3), dtype=dtype
+            )
+            buffer = encode_array(
+                arr,
+                photometric_interpretation=PI.RGB,
+                use_mct=False,
+                transformation_type=0,
+                compression_ratios=[5, 2, 1],
+            )
+            out = decode(buffer)
+            param = parse_j2k(buffer)
+            assert param["precision"] == bit_depth
+            assert param["is_signed"] is False
+            assert param["layers"] == 3
+            assert param["components"] == 3
+            assert param["transformation"] == "5-3 Reversible"
+
+            assert out.dtype.kind == "u"
+            assert np.array_equal(arr, out)
+
+            arr = np.random.randint(
+                0, high=maximum + 1, size=(rows, cols, 4), dtype=dtype
+            )
+            buffer = encode_array(
+                arr,
+                photometric_interpretation=5,
+                use_mct=False,
+                transformation_type=0,
+                compression_ratios=[5, 2, 1],
+            )
+            out = decode(buffer)
+            param = parse_j2k(buffer)
+            assert param["precision"] == bit_depth
+            assert param["is_signed"] is False
+            assert param["layers"] == 3
+            assert param["components"] == 4
+            assert param["transformation"] == "5-3 Reversible"
 
             assert out.dtype.kind == "u"
             assert np.array_equal(arr, out)
@@ -493,6 +577,7 @@ class TestEncode:
             assert param["is_signed"] is False
             assert param["layers"] == 1
             assert param["components"] == 1
+            assert param["transformation"] == "5-3 Reversible"
 
             assert out.dtype.kind == "u"
             assert np.array_equal(arr, out)
@@ -508,6 +593,55 @@ class TestEncode:
             assert param["is_signed"] is False
             assert param["layers"] == 1
             assert param["components"] == 3
+            assert param["transformation"] == "5-3 Reversible"
+
+            assert out.dtype.kind == "u"
+            assert np.array_equal(arr, out)
+
+    def test_lossless_unsigned_u4_explicit_layers(self):
+        """Test encoding unsigned data for bit-depth 17-32 with explicit number of layers"""
+        rows = 123
+        cols = 234
+        planes = 3
+        for bit_depth in range(17, 25):
+            maximum = 2**bit_depth - 1
+            arr = np.random.randint(0, high=maximum + 1, size=(rows, cols), dtype="u4")
+            buffer = encode_array(
+                arr,
+                photometric_interpretation=PI.MONOCHROME2,
+                transformation_type=0,
+                compression_ratios=[5, 2, 1],
+            )
+            out = decode(buffer)
+
+            param = parse_j2k(buffer)
+            assert param["precision"] == bit_depth
+            assert param["is_signed"] is False
+            assert param["layers"] == 3
+            assert param["components"] == 1
+            assert param["transformation"] == "5-3 Reversible"
+
+            assert out.dtype.kind == "u"
+            assert np.array_equal(arr, out)
+
+            arr = np.random.randint(
+                0, high=maximum + 1, size=(rows, cols, planes), dtype="u4"
+            )
+            buffer = encode_array(
+                arr,
+                photometric_interpretation=PI.RGB,
+                use_mct=False,
+                transformation_type=0,
+                compression_ratios=[5, 2, 1],
+            )
+            out = decode(buffer)
+
+            param = parse_j2k(buffer)
+            assert param["precision"] == bit_depth
+            assert param["is_signed"] is False
+            assert param["layers"] == 3
+            assert param["components"] == 3
+            assert param["transformation"] == "5-3 Reversible"
 
             assert out.dtype.kind == "u"
             assert np.array_equal(arr, out)
@@ -531,6 +665,7 @@ class TestEncode:
             assert param["is_signed"] is True
             assert param["layers"] == 1
             assert param["components"] == 1
+            assert param["transformation"] == "5-3 Reversible"
 
             assert out.dtype.kind == "i"
             assert np.array_equal(arr, out)
@@ -549,6 +684,7 @@ class TestEncode:
             assert param["is_signed"] is True
             assert param["layers"] == 1
             assert param["components"] == 3
+            assert param["transformation"] == "5-3 Reversible"
 
             assert out.dtype.kind == "i"
             assert np.array_equal(arr, out)
@@ -564,6 +700,83 @@ class TestEncode:
             assert param["is_signed"] is True
             assert param["layers"] == 1
             assert param["components"] == 4
+            assert param["transformation"] == "5-3 Reversible"
+
+            assert out.dtype.kind == "i"
+            assert np.array_equal(arr, out)
+
+    def test_lossless_signed_explicit_layers(self):
+        """Test encoding signed data for bit-depth 1-16 with explicit number of layers"""
+        rows = 123
+        cols = 543
+        for bit_depth in range(2, 17):
+            maximum = 2 ** (bit_depth - 1) - 1
+            minimum = -(2 ** (bit_depth - 1))
+            dtype = f"i{math.ceil(bit_depth / 8)}"
+            arr = np.random.randint(
+                low=minimum, high=maximum + 1, size=(rows, cols), dtype=dtype
+            )
+            buffer = encode_array(
+                arr,
+                photometric_interpretation=PI.MONOCHROME2,
+                transformation_type=0,
+                compression_ratios=[5, 2, 1],
+            )
+            out = decode(buffer)
+
+            param = parse_j2k(buffer)
+            assert param["precision"] == bit_depth
+            assert param["is_signed"] is True
+            assert param["layers"] == 3
+            assert param["components"] == 1
+            assert param["transformation"] == "5-3 Reversible"
+
+            assert out.dtype.kind == "i"
+            assert np.array_equal(arr, out)
+
+            maximum = 2 ** (bit_depth - 1) - 1
+            minimum = -(2 ** (bit_depth - 1))
+            dtype = f"i{math.ceil(bit_depth / 8)}"
+            arr = np.random.randint(
+                low=minimum, high=maximum, size=(rows, cols, 3), dtype=dtype
+            )
+            buffer = encode_array(
+                arr,
+                photometric_interpretation=PI.RGB,
+                use_mct=False,
+                transformation_type=0,
+                compression_ratios=[5, 2, 1],
+            )
+            out = decode(buffer)
+
+            param = parse_j2k(buffer)
+            assert param["precision"] == bit_depth
+            assert param["is_signed"] is True
+            assert param["layers"] == 3
+            assert param["components"] == 3
+            assert param["transformation"] == "5-3 Reversible"
+
+            assert out.dtype.kind == "i"
+            assert np.array_equal(arr, out)
+
+            arr = np.random.randint(
+                low=minimum, high=maximum, size=(rows, cols, 4), dtype=dtype
+            )
+            buffer = encode_array(
+                arr,
+                photometric_interpretation=5,
+                use_mct=False,
+                transformation_type=0,
+                compression_ratios=[5, 2, 1],
+            )
+            out = decode(buffer)
+
+            param = parse_j2k(buffer)
+            assert param["precision"] == bit_depth
+            assert param["is_signed"] is True
+            assert param["layers"] == 3
+            assert param["components"] == 4
+            assert param["transformation"] == "5-3 Reversible"
 
             assert out.dtype.kind == "i"
             assert np.array_equal(arr, out)
@@ -587,6 +800,7 @@ class TestEncode:
             assert param["is_signed"] is True
             assert param["layers"] == 1
             assert param["components"] == 1
+            assert param["transformation"] == "5-3 Reversible"
 
             assert out.dtype.kind == "i"
             assert np.array_equal(arr, out)
@@ -602,6 +816,7 @@ class TestEncode:
             assert param["is_signed"] is True
             assert param["layers"] == 1
             assert param["components"] == 3
+            assert param["transformation"] == "5-3 Reversible"
 
             assert out.dtype.kind == "i"
             assert np.array_equal(arr, out)
@@ -621,6 +836,7 @@ class TestEncode:
             assert param["is_signed"] is False
             assert param["layers"] == 3
             assert param["components"] == 1
+            assert param["transformation"] == "9-7 Irreversible"
 
             assert out.dtype.kind == "u"
             assert np.allclose(arr, out, atol=5)
@@ -632,12 +848,45 @@ class TestEncode:
             assert param["is_signed"] is False
             assert param["layers"] == 3
             assert param["components"] == 1
+            assert param["transformation"] == "9-7 Irreversible"
+
+            assert out.dtype.kind == "u"
+            assert np.allclose(arr, out, atol=5)
+
+    def test_lossy_unsigned(self):
+        """Test lossy encoding with unsigned data with one layer"""
+        rows = 123
+        cols = 234
+        for bit_depth in range(1, 17):
+            maximum = 2**bit_depth - 1
+            dtype = f"u{math.ceil(bit_depth / 8)}"
+            arr = np.random.randint(0, high=maximum + 1, size=(rows, cols), dtype=dtype)
+            buffer = encode_array(arr, transformation_type=1)
+            out = decode(buffer)
+            param = parse_j2k(buffer)
+            assert param["precision"] == bit_depth
+            assert param["is_signed"] is False
+            assert param["layers"] == 1
+            assert param["components"] == 1
+            assert param["transformation"] == "9-7 Irreversible"
+
+            assert out.dtype.kind == "u"
+            assert np.allclose(arr, out, atol=5)
+
+            buffer = encode_array(arr, transformation_type=1)
+            out = decode(buffer)
+            param = parse_j2k(buffer)
+            assert param["precision"] == bit_depth
+            assert param["is_signed"] is False
+            assert param["layers"] == 1
+            assert param["components"] == 1
+            assert param["transformation"] == "9-7 Irreversible"
 
             assert out.dtype.kind == "u"
             assert np.allclose(arr, out, atol=5)
 
     def test_lossy_signed(self):
-        """Test lossy encoding with unsigned data"""
+        """Test lossy encoding with signed data"""
         rows = 123
         cols = 234
         for bit_depth in range(1, 17):
@@ -654,6 +903,7 @@ class TestEncode:
             assert param["is_signed"] is True
             assert param["layers"] == 3
             assert param["components"] == 1
+            assert param["transformation"] == "9-7 Irreversible"
 
             assert out.dtype.kind == "i"
             assert np.allclose(arr, out, atol=5)
@@ -665,6 +915,42 @@ class TestEncode:
             assert param["is_signed"] is True
             assert param["layers"] == 3
             assert param["components"] == 1
+            assert param["transformation"] == "9-7 Irreversible"
+
+            assert out.dtype.kind == "i"
+            assert np.allclose(arr, out, atol=5)
+
+    def test_lossy_signed(self):
+        """Test lossy encoding with signed data with one layer"""
+        rows = 123
+        cols = 234
+        for bit_depth in range(1, 17):
+            maximum = 2 ** (bit_depth - 1) - 1
+            minimum = -(2 ** (bit_depth - 1))
+            dtype = f"i{math.ceil(bit_depth / 8)}"
+            arr = np.random.randint(
+                low=minimum, high=maximum + 1, size=(rows, cols), dtype=dtype
+            )
+            buffer = encode_array(arr, transformation_type=1)
+            out = decode(buffer)
+            param = parse_j2k(buffer)
+            assert param["precision"] == bit_depth
+            assert param["is_signed"] is True
+            assert param["layers"] == 1
+            assert param["components"] == 1
+            assert param["transformation"] == "9-7 Irreversible"
+
+            assert out.dtype.kind == "i"
+            assert np.allclose(arr, out, atol=5)
+
+            buffer = encode_array(arr, transformation_type=1)
+            out = decode(buffer)
+            param = parse_j2k(buffer)
+            assert param["precision"] == bit_depth
+            assert param["is_signed"] is True
+            assert param["layers"] == 1
+            assert param["components"] == 1
+            assert param["transformation"] == "9-7 Irreversible"
 
             assert out.dtype.kind == "i"
             assert np.allclose(arr, out, atol=5)
@@ -972,6 +1258,21 @@ class TestEncodeBuffer:
                 b"\x00\x01\x02\x03", 1, 1, 4, 8, False, photometric_interpretation=2
             )
 
+    def test_invalid_transformation_type(self):
+        """Test invalid explicit transformation type"""
+        msg = "Invalid 'transformation_type' value '2', must be 0, 1 or -1"
+        with pytest.raises(ValueError, match=msg):
+            encode_buffer(
+                b"\x00",
+                1,
+                1,
+                1,
+                bits_stored=8,
+                is_signed=False,
+                transformation_type=2,
+                compression_ratios=[1],
+            )
+
     def test_encoding_failures_raise(self):
         """Miscellaneous test to check that failures are handled properly."""
         # Not exhaustive!
@@ -1157,6 +1458,7 @@ class TestEncodeBuffer:
         assert param["is_signed"] is False
         assert param["layers"] == 1
         assert param["components"] == 1
+        assert param["transformation"] == "5-3 Reversible"
 
         assert out.dtype.kind == "u"
         assert np.array_equal(mono, out)
@@ -1180,6 +1482,7 @@ class TestEncodeBuffer:
         assert param["is_signed"] is False
         assert param["layers"] == 1
         assert param["components"] == 3
+        assert param["transformation"] == "5-3 Reversible"
 
         assert out.dtype.kind == "u"
         assert np.array_equal(arr, out)
@@ -1206,6 +1509,7 @@ class TestEncodeBuffer:
             assert param["is_signed"] is False
             assert param["layers"] == 1
             assert param["components"] == 1
+            assert param["transformation"] == "5-3 Reversible"
 
             assert out.dtype.kind == "u"
             assert np.array_equal(arr, out)
@@ -1229,6 +1533,7 @@ class TestEncodeBuffer:
             assert param["is_signed"] is False
             assert param["layers"] == 1
             assert param["components"] == 3
+            assert param["transformation"] == "5-3 Reversible"
 
             assert out.dtype.kind == "u"
             assert np.array_equal(arr, out)
@@ -1252,6 +1557,7 @@ class TestEncodeBuffer:
             assert param["is_signed"] is False
             assert param["layers"] == 1
             assert param["components"] == 4
+            assert param["transformation"] == "5-3 Reversible"
 
             assert out.dtype.kind == "u"
             assert np.array_equal(arr, out)
@@ -1316,6 +1622,7 @@ class TestEncodeBuffer:
             assert param["is_signed"] is False
             assert param["layers"] == 1
             assert param["components"] == 1
+            assert param["transformation"] == "5-3 Reversible"
 
             assert out.dtype.kind == "u"
             assert np.array_equal(arr, out)
@@ -1342,6 +1649,7 @@ class TestEncodeBuffer:
             assert param["is_signed"] is False
             assert param["layers"] == 1
             assert param["components"] == 3
+            assert param["transformation"] == "5-3 Reversible"
 
             assert out.dtype.kind == "u"
             assert np.array_equal(arr, out)
@@ -1368,6 +1676,7 @@ class TestEncodeBuffer:
             assert param["is_signed"] is False
             assert param["layers"] == 1
             assert param["components"] == 4
+            assert param["transformation"] == "5-3 Reversible"
 
             assert out.dtype.kind == "u"
             assert np.array_equal(arr, out)
@@ -1431,6 +1740,7 @@ class TestEncodeBuffer:
             assert param["is_signed"] is False
             assert param["layers"] == 1
             assert param["components"] == 1
+            assert param["transformation"] == "5-3 Reversible"
 
             assert out.dtype.kind == "u"
             assert np.array_equal(arr, out)
@@ -1458,6 +1768,7 @@ class TestEncodeBuffer:
             assert param["is_signed"] is False
             assert param["layers"] == 1
             assert param["components"] == 3
+            assert param["transformation"] == "5-3 Reversible"
 
             assert out.dtype.kind == "u"
             assert np.array_equal(arr, out)
@@ -1526,6 +1837,7 @@ class TestEncodeBuffer:
             assert param["is_signed"] is True
             assert param["layers"] == 1
             assert param["components"] == 1
+            assert param["transformation"] == "5-3 Reversible"
 
             assert out.dtype.kind == "i"
             assert np.array_equal(arr, out)
@@ -1552,6 +1864,7 @@ class TestEncodeBuffer:
             assert param["is_signed"] is True
             assert param["layers"] == 1
             assert param["components"] == 3
+            assert param["transformation"] == "5-3 Reversible"
 
             assert out.dtype.kind == "i"
             assert np.array_equal(arr, out)
@@ -1576,6 +1889,7 @@ class TestEncodeBuffer:
             assert param["is_signed"] is True
             assert param["layers"] == 1
             assert param["components"] == 4
+            assert param["transformation"] == "5-3 Reversible"
 
             assert out.dtype.kind == "i"
             assert np.array_equal(arr, out)
@@ -1649,6 +1963,7 @@ class TestEncodeBuffer:
             assert param["is_signed"] is True
             assert param["layers"] == 1
             assert param["components"] == 1
+            assert param["transformation"] == "5-3 Reversible"
 
             assert out.dtype.kind == "i"
             assert np.array_equal(arr, out)
@@ -1678,6 +1993,7 @@ class TestEncodeBuffer:
             assert param["is_signed"] is True
             assert param["layers"] == 1
             assert param["components"] == 3
+            assert param["transformation"] == "5-3 Reversible"
 
             assert out.dtype.kind == "i"
             assert np.array_equal(arr, out)
@@ -1705,6 +2021,7 @@ class TestEncodeBuffer:
             assert param["is_signed"] is True
             assert param["layers"] == 1
             assert param["components"] == 4
+            assert param["transformation"] == "5-3 Reversible"
 
             assert out.dtype.kind == "i"
             assert np.array_equal(arr, out)
@@ -1780,6 +2097,7 @@ class TestEncodeBuffer:
             assert param["is_signed"] is True
             assert param["layers"] == 1
             assert param["components"] == 1
+            assert param["transformation"] == "5-3 Reversible"
 
             assert out.dtype.kind == "i"
             assert np.array_equal(arr, out)
@@ -1807,6 +2125,7 @@ class TestEncodeBuffer:
             assert param["is_signed"] is True
             assert param["layers"] == 1
             assert param["components"] == 3
+            assert param["transformation"] == "5-3 Reversible"
 
             assert out.dtype.kind == "i"
             assert np.array_equal(arr, out)
@@ -1891,6 +2210,7 @@ class TestEncodeBuffer:
             assert param["is_signed"] is False
             assert param["layers"] == 3
             assert param["components"] == 1
+            assert param["transformation"] == "9-7 Irreversible"
 
             assert out.dtype.kind == "u"
             assert np.allclose(arr, out, atol=5)
@@ -1910,6 +2230,7 @@ class TestEncodeBuffer:
             assert param["is_signed"] is False
             assert param["layers"] == 3
             assert param["components"] == 1
+            assert param["transformation"] == "9-7 Irreversible"
 
             assert out.dtype.kind == "u"
             assert np.allclose(arr, out, atol=5)
@@ -1943,6 +2264,7 @@ class TestEncodeBuffer:
             assert param["is_signed"] is True
             assert param["layers"] == 3
             assert param["components"] == 1
+            assert param["transformation"] == "9-7 Irreversible"
 
             assert out.dtype.kind == "i"
             assert np.allclose(arr, out, atol=5)
@@ -1962,6 +2284,7 @@ class TestEncodeBuffer:
             assert param["is_signed"] is True
             assert param["layers"] == 3
             assert param["components"] == 1
+            assert param["transformation"] == "9-7 Irreversible"
 
             assert out.dtype.kind == "i"
             assert np.allclose(arr, out, atol=5)
@@ -2111,6 +2434,7 @@ class TestEncodeBuffer:
             assert param["is_signed"] is False
             assert param["layers"] == 1
             assert param["components"] == 1
+            assert param["transformation"] == "5-3 Reversible"
 
             assert out.dtype.kind == "u"
             assert np.array_equal(arr, out)
@@ -2134,6 +2458,7 @@ class TestEncodeBuffer:
             assert param["is_signed"] is False
             assert param["layers"] == 1
             assert param["components"] == 3
+            assert param["transformation"] == "5-3 Reversible"
 
             assert out.dtype.kind == "u"
             assert np.array_equal(arr, out)
@@ -2157,6 +2482,7 @@ class TestEncodeBuffer:
             assert param["is_signed"] is False
             assert param["layers"] == 1
             assert param["components"] == 4
+            assert param["transformation"] == "5-3 Reversible"
 
             assert out.dtype.kind == "u"
             assert np.array_equal(arr, out)

--- a/openjpeg/utils.py
+++ b/openjpeg/utils.py
@@ -436,6 +436,7 @@ def encode_array(
     codec_format: int = 0,
     add_tlm: bool = False,
     add_plt: bool = False,
+    transformation_type: int = -1,
     **kwargs: Any,
 ) -> bytes:
     """Return the JPEG 2000 compressed `arr`.
@@ -532,6 +533,10 @@ def encode_array(
         Add packet length, tile-part length markers (PLT) to the codestream. This
         can help to speed up decoding of parts of very large images for some
         decoders.
+    transformation_type: int, optional
+        Set the transformation type. 0 = 5-3 reversible, 1 = 9-7 irreversible,
+        -1 = (default) automatically determined from the compression_ratios or
+        signal_noise_ratios argument
 
     Returns
     -------
@@ -564,6 +569,7 @@ def encode_array(
         codec_format,
         add_tlm,
         add_plt,
+        transformation_type,
     )
 
     if return_code != 0:
@@ -592,6 +598,7 @@ def encode_buffer(
     codec_format: int = 0,
     add_tlm: bool = False,
     add_plt: bool = False,
+    transformation_type: int = -1,
     **kwargs: Any,
 ) -> bytes:
     """Return the JPEG 2000 compressed `src`.
@@ -697,6 +704,10 @@ def encode_buffer(
         Add packet length, tile-part length markers (PLT) to the codestream. This
         can help to speed up decoding of parts of very large images for some
         decoders.
+    transformation_type: int, optional
+        Set the transformation type. 0 = 5-3 reversible, 1 = 9-7 irreversible,
+        -1 = (default) automatically determined from the compression_ratios or
+        signal_noise_ratios argument
 
     Returns
     -------
@@ -724,6 +735,7 @@ def encode_buffer(
         codec_format,
         add_tlm,
         add_plt,
+        transformation_type,
     )
 
     if return_code != 0:


### PR DESCRIPTION
This keeps the current behaviour by default, but allows explicit set of the transformation if needed.

I think the current behaviour is a good default. Unfortunately, I have a profile requirement for use of 5-3 and multiple layers.

I've added tests to check that the existing behaviour is kept.